### PR TITLE
Delete does not occur if deleted value is a dict

### DIFF
--- a/pyArango/document.py
+++ b/pyArango/document.py
@@ -170,6 +170,11 @@ class DocumentStore(object) :
             del(self.patchStore[k])
         except :
             pass
+        
+        try:
+            del(self.subStores[k])
+        except:
+            pass
 
     def __contains__(self, k) :
         """returns true or false weither the store has a key k"""


### PR DESCRIPTION
Reason is the value is not deleted from self.subStores, and therefore gets overrided.

See diff