### PR TITLE
This commit brings pyArango significantly closer to PEP 8 complience.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,6 +6,34 @@ pyArango
 .. image:: https://img.shields.io/badge/python-2.7%2C%203.5-blue.svg
 .. image:: https://img.shields.io/badge/arangodb-3.0-blue.svg
 
+This repository is a fork of the pyArango community repository.
+
+Why this fork?
+
+Any Python user can interact directly with the ArangoDB HTTP API
+by creating the appropriate json request strings and using the
+Requests library to communicate with the ArangoDB HTTP API.
+
+However, this situation is clumsy, error prone, and slow. This
+is why it is desirable to develop a Pythonic API interface for 
+Python developers.
+
+Unfortunately, the Python API developed by the ArangoDB community 
+Github account was originally designed with Javascript developers
+in mind. The style and coding practices followed are the 
+result of Javascript developers writing code using their preferred
+styles and patterns.
+
+In particular, the authors of the Pyarango Python API have not 
+followed PEP8, I can say, at all.
+
+I did submit a pull request. Unfortunately, however, the authors
+believed that PEP8 was an opinion at best, and did not accept the PR.
+
+This fork therefore fills the need for a PYTHONIC way to interact with 
+the ArangoDB HTTP API.
+
+
 NoSQL is really cool, but in this harsh world it is impossible to live without field validation.
 
 **WARNING**: The last versions of pyArango are only compatible with ArangoDB 3.X. For the old version checkout the branch ArangoDBV2_

--- a/pyArango/collection.py
+++ b/pyArango/collection.py
@@ -513,6 +513,7 @@ class Collection(with_metaclass(CollectionMetaclass, object)):
         """
         example_dict should be something like {'age': 28}
         """
+        print("\n\nI am fetching by example!!\n\n\n\n\n")
         return self.simple_query('by-example', raw_results, example = example_dict, batch_size = batch_size, **query_args)
 
     def fetch_first_example(self, example_dict, raw_results = False):

--- a/pyArango/collection.py
+++ b/pyArango/collection.py
@@ -2,725 +2,873 @@ import json
 import types
 from future.utils import with_metaclass
 from . import consts as CONST
-
 from .document import Document, Edge
-
 from .theExceptions import ValidationError, SchemaViolation, CreationError, UpdateError, DeletionError, InvalidDocument, ExportError, DocumentNotFoundError
-
 from .query import SimpleQuery
 from .index import Index
 
-__all__ = ["Collection", "Edges", "Field", "DocumentCache", "CachedDoc", "Collection_metaclass", "getCollectionClass", "isCollection", "isDocumentCollection", "isEdgeCollection", "getCollectionClasses"]
 
-class CachedDoc(object) :
-    """A cached document"""
-    def __init__(self, document, prev, nextDoc) :
-        self.prev = prev
+__all__ = [
+        "Collection",
+        "Edges",
+        "Field",
+        "DocumentCache",
+        "CachedDoc",
+        "CollectionMetaclass",
+        "get_collection_class",
+        "is_collection",
+        "is_document_collection",
+        "is_edge_collection",
+        "get_collection_classes"
+        ]
+
+
+class CachedDoc(object):
+    """
+    A cached document
+    """
+    def __init__(self, document, previous, next_document):
+        self.previous = previous
         self.document = document
-        self.nextDoc = nextDoc
+        self.next_document = next_document
         self._key = document._key
 
-    def __getitem__(self, k) :
+    def __getitem__(self, k):
         return self.document[k]
 
-    def __setitem__(self, k, v) :
+    def __setitem__(self, k, v):
         self.document[k] = v
 
-    def __getattribute__(self, k) :
-        try :
+    def __getattribute__(self, k):
+        try:
             return object.__getattribute__(self, k)
         except Exception as e1:
-            try :
+            try:
                 return getattr(self.document, k)
-            except Exception as e2 :
+            except Exception as e2:
                 raise e2
 
-class DocumentCache(object) :
-    "Document cache for collection, with insert, deletes and updates in O(1)"
 
-    def __init__(self, cacheSize) :
-        self.cacheSize = cacheSize
-        self.cacheStore = {}
+class DocumentCache(object):
+    """
+    Document cache for collection, with insert, deletes and updates in O(1)
+    """
+
+    def __init__(self, cache_size):
+        self.cache_size = cache_size
+        self.cache_store = {}
         self.head = None
         self.tail = None
 
-    def cache(self, doc) :
-        if doc._key in self.cacheStore :
-            ret = self.cacheStore[doc._key]
-            if ret.prev is not None :
-                ret.prev.nextDoc = ret.nextDoc
-                self.head.prev = ret
-                ret.nextDoc = self.head
+    def cache(self, document):
+        if document._key in self.cache_store:
+            ret = self.cache_store[document._key]
+            if ret.previous is not None:
+                ret.previous.next_document = ret.next_document
+                self.head.previous = ret
+                ret.next_document = self.head
                 self.head = ret
             return self.head
-        else :
-            if len(self.cacheStore) == 0 :
-                ret = CachedDoc(doc, prev = None, nextDoc = None)
+        else:
+            if len(self.cache_store) == 0:
+                ret = CachedDoc(document, previous=None, next_document=None)
                 self.head = ret
                 self.tail = self.head
-                self.cacheStore[doc._key] = ret
-            else :
-                if len(self.cacheStore) >= self.cacheSize :
-                    del(self.cacheStore[self.tail._key])
-                    self.tail = self.tail.prev
-                    self.tail.nextDoc = None
+                self.cache_store[document._key] = ret
+            else:
+                if len(self.cache_store) >= self.cache_size:
+                    del(self.cache_store[self.tail._key])
+                    self.tail = self.tail.previous
+                    self.tail.next_document = None
 
-                ret = CachedDoc(doc, prev = None, nextDoc = self.head)
-                self.head.prev = ret
-                self.head = self.head.prev
-                self.cacheStore[doc._key] = ret
+                ret = CachedDoc(document, previous=None, next_document=self.head)
+                self.head.previous = ret
+                self.head = self.head.previous
+                self.cache_store[document._key] = ret
 
-    def delete(self, _key) :
-        "removes a document from the cache"
-        try :
-            doc = self.cacheStore[_key]
-            doc.prev.nextDoc = doc.nextDoc
-            doc.nextDoc.prev = doc.prev
-            del(self.cacheStore[_key])
-        except KeyError :
+    def delete(self, _key):
+        """
+        removes a document from the cache
+        """
+
+        try:
+            document = self.cache_store[_key]
+            document.previous.next_document = doc.next_document
+            document.next_document.previous = document.previous
+            del(self.cache_store[_key])
+
+        except KeyError:
             raise KeyError("Document with _key %s is not available in cache" % _key)
 
-    def getChain(self) :
-        "returns a list of keys representing the chain of documents"
-        l = []
-        h = self.head
-        while h :
-            l.append(h._key)
-            h = h.nextDoc
-        return l
+    def getChain(self):
+        """
+        returns a list of keys representing the chain of documents
+        """
+        chain = []
+        head = self.head
+        while head:
+            chain.append(head._key)
+            head = head.next_document
+        return chain
 
-    def stringify(self) :
-        "a pretty str version of getChain()"
-        l = []
-        h = self.head
-        while h :
-            l.append(str(h._key))
-            h = h.nextDoc
-        return "<->".join(l)
+    def stringify(self):
+        """
+        A pretty str version of getChain()
+        """
+        chain = []
+        head = self.head
+        while head:
+            chain.append(str(head._key))
+            head = head.next_document
+        return "<->".join(chain)
 
-    def __getitem__(self, _key) :
-        try :
-            ret = self.cacheStore[_key]
+    def __getitem__(self, _key):
+        try:
+            ret = self.cache_store[_key]
             self.cache(ret)
             return ret
-        except KeyError :
+        except KeyError:
             raise KeyError("Document with _key %s is not available in cache" % _key)
 
-    def __repr__(self) :
-        return "[DocumentCache, size: %d, full: %d]" %(self.cacheSize, len(self.cacheStore))
+    def __repr__(self):
+        return "[DocumentCache, size: %d, full: %d]" %(self.cache_size, len(self.cache_store))
 
-class Field(object) :
-    """The class for defining pyArango fields."""
-    def __init__(self, validators = None, default = "") :
+
+class Field(object):
+    """
+    The class for defining pyArango fields.
+    """
+    def __init__(self, validators = None, default = ""):
         """validators must be a list of validators"""
         if not validators:
             validators = []
         self.validators = validators
         self.default = default
 
-    def validate(self, value) :
-        """checks the validity of 'value' given the lits of validators"""
-        for v in self.validators :
-            v.validate(value)
+    def validate(self, value):
+        """
+        checks the validity of 'value' given the lits of validators
+        """
+        for validator in self.validators:
+            validator.validate(value)
         return True
 
-    def __str__(self) :
-        strv = []
-        for v in self.validators :
-            strv.append(str(v))
-        return "<Field, validators: '%s'>" % ', '.join(strv)
+    def __str__(self):
+        string_validators = []
+        for validator in self.validators:
+            string_validators.append(str(validator))
+        return "<Field, validators: '%s'>" % ', '.join(string_validators)
 
-class Collection_metaclass(type) :
-    """The metaclass that takes care of keeping a register of all collection types"""
-    collectionClasses = {}
 
-    _validationDefault = {
-            'on_save' : False,
-            'on_set' : False,
-            'on_load' : False,
-            'allow_foreign_fields' : True
+class CollectionMetaclass(type):
+    """
+    The metaclass that takes care of keeping a register of all collection types
+    """
+    collection_classes = {}
+
+    _validation_default = {
+            'on_save': False,
+            'on_set': False,
+            'on_load': False,
+            'allow_foreign_fields': True
         }
 
-    def __new__(cls, name, bases, attrs) :
-        def check_set_ConfigDict(dictName) :
-            defaultDict = getattr(cls, "%sDefault" % dictName)
+    def __new__(cls, name, bases, attrs):
+        def check_set_config_dict(dict_name):
+            default_dict = getattr(cls, "%s_default" % dict_name)
 
-            if dictName not in attrs :
-                attrs[dictName] = defaultDict
-            else :
-                for k, v in attrs[dictName].items() :
-                    if k not in defaultDict :
+            if dict_name not in attrs:
+                attrs[dict_name] = default_dict
+            else:
+                for k, v in attrs[dict_name].items():
+                    if k not in default_dict:
                         raise KeyError("Unknown validation parameter '%s' for class '%s'"  %(k, name))
-                    if type(v) is not type(defaultDict[k]) :
-                        raise ValueError("'%s' parameter '%s' for class '%s' is of type '%s' instead of '%s'"  %(dictName, k, name, type(v), type(defaultDict[k])))
+                    if type(v) is not type(default_dict[k]):
+                        raise ValueError("'%s' parameter '%s' for class '%s' is of type '%s' instead of '%s'"  %(dict_name, k, name, type(v), type(default_dict[k])))
 
-                for k, v in defaultDict.items() :
-                    if k not in attrs[dictName] :
-                        attrs[dictName][k] = v
+                for k, v in default_dict.items():
+                    if k not in attrs[dict_name]:
+                        attrs[dict_name][k] = v
 
-        check_set_ConfigDict('_validation')
-        clsObj = type.__new__(cls, name, bases, attrs)
-        Collection_metaclass.collectionClasses[name] = clsObj
+        check_set_config_dict('_validation')
+        class_object = type.__new__(cls, name, bases, attrs)
+        CollectionMetaclass.collection_classes[name] = class_object
 
-        return clsObj
-
-    @classmethod
-    def getCollectionClass(cls, name) :
-        """Return the class object of a collection given its 'name'"""
-        try :
-            return cls.collectionClasses[name]
-        except KeyError :
-            raise KeyError( "There is no Collection Class of type: '%s'; currently supported values: [%s]" % (name, ', '.join(getCollectionClasses().keys())) )
+        return class_object
 
     @classmethod
-    def isCollection(cls, name) :
-        """return true or false wether 'name' is the name of collection."""
-        return name in cls.collectionClasses
+    def get_collection_class(cls, name):
+        """
+        Return the class object of a collection given its 'name'
+        """
+        try:
+            return cls.collection_classes[name]
+        except KeyError:
+            raise KeyError("There is no Collection Class of type: '%s'; currently supported values: [%s]" % (name, ', '.join(get_collection_classes().keys())))
 
     @classmethod
-    def isDocumentCollection(cls, name) :
-        """return true or false wether 'name' is the name of a document collection."""
-        try :
-            col = cls.getCollectionClass(name)
+    def is_collection(cls, name):
+        """
+        Return true or false wether 'name' is the name of collection.
+        """
+        return name in cls.collection_classes
+
+    @classmethod
+    def is_document_collection(cls, name):
+        """
+        return true or false wether 'name' is the name of a document collection.
+        """
+        try:
+            col = cls.get_collection_class(name)
             return issubclass(col, Collection)
-        except KeyError :
+        except KeyError:
             return False
 
     @classmethod
-    def isEdgeCollection(cls, name) :
-        """return true or false wether 'name' is the name of an edge collection."""
-        try :
-            col = cls.getCollectionClass(name)
+    def is_edge_collection(cls, name):
+        """
+        return true or false wether 'name' is the name of an edge collection.
+        """
+        try:
+            col = cls.get_collection_class(name)
             return issubclass(col, Edges)
-        except KeyError :
+        except KeyError:
             return False
 
-def getCollectionClass(name) :
-    """return true or false wether 'name' is the name of collection."""
-    return Collection_metaclass.getCollectionClass(name)
+def get_collection_class(name):
+    """
+    Return true or false wether 'name' is the name of collection.
+    """
+    return CollectionMetaclass.get_collection_class(name)
 
-def isCollection(name) :
-    """return true or false wether 'name' is the name of a document collection."""
-    return Collection_metaclass.isCollection(name)
 
-def isDocumentCollection(name) :
-    """return true or false wether 'name' is the name of a document collection."""
-    return Collection_metaclass.isDocumentCollection(name)
+def is_collection(name):
+    """
+    Return true or false wether 'name' is the name of a document collection.
+    """
+    return CollectionMetaclass.is_collection(name)
 
-def isEdgeCollection(name) :
-    """return true or false wether 'name' is the name of an edge collection."""
-    return Collection_metaclass.isEdgeCollection(name)
 
-def getCollectionClasses() :
-    """returns a dictionary of all defined collection classes"""
-    return Collection_metaclass.collectionClasses
+def is_document_collection(name):
+    """
+    Return true or false wether 'name' is the name of a document collection.
+    """
+    return CollectionMetaclass.is_document_collection(name)
 
-class Collection(with_metaclass(Collection_metaclass, object)) :
-    """A document collection. Collections are meant to be instanciated by databases"""
+
+def is_edge_collection(name):
+    """
+    Return true or false wether 'name' is the name of an edge collection.
+    """
+    return CollectionMetaclass.is_edge_collection(name)
+
+
+def get_collection_classes():
+    """
+    Returns a dictionary of all defined collection classes
+    """
+    return CollectionMetaclass.collectionClasses
+
+
+class Collection(with_metaclass(CollectionMetaclass, object)):
+    """
+    A document collection. Collections are meant to be instanciated by databases
+    """
     #here you specify the fields that you want for the documents in your collection
     _fields = {}
 
     _validation = {
-        'on_save' : False,
-        'on_set' : False,
-        'on_load' : False,
-        'allow_foreign_fields' : True
+        'on_save': False,
+        'on_set': False,
+        'on_load': False,
+        'allow_foreign_fields': True
     }
 
-    arangoPrivates = ["_id", "_key", "_rev"]
+    arango_privates = ["_id", "_key", "_rev"]
 
-    def __init__(self, database, jsonData) :
+    def __init__(self, database, json_data):
 
-        def getDefaultDoc(fields, dct) :
-            for k, v in fields.items() :
-                if isinstance(v, dict) :
-                    dct[k] = getDefaultDoc(fields[k], {})
-                elif isinstance(v, Field) :
+        def get_default_document(fields, dct):
+            for k, v in fields.items():
+                if isinstance(v, dict):
+                    dct[k] = get_default_document(fields[k], {})
+                elif isinstance(v, Field):
                     dct[k] = v.default
-                else :
+                else:
                     raise ValueError("Field '%s' is of invalid type '%s'" % (k, type(v)) )
             return dct
 
         self.database = database
         self.connection = self.database.connection
         self.name = self.__class__.__name__
-        for k in jsonData :
-            setattr(self, k, jsonData[k])
+        for k in json_data:
+            setattr(self, k, json_data[k])
 
         self.URL = "%s/collection/%s" % (self.database.URL, self.name)
         self.documentsURL = "%s/document" % (self.database.URL)
-        self.documentCache = None
+        self.document_cache = None
 
-        self.documentClass = Document
+        self.document_class = Document
         self.indexes = {
-            "primary" : {},
-            "hash" : {},
-            "skiplist" : {},
-            "geo" : {},
-            "fulltext" : {},
+            "primary": {},
+            "hash": {},
+            "skiplist": {},
+            "geo": {},
+            "fulltext": {},
         }
 
-        self.defaultDocument = getDefaultDoc(self._fields, {})
+        self.default_document = get_default_document(self._fields, {})
 
-    def getIndexes(self) :
-        """Fills self.indexes with all the indexes associates with the collection and returns it"""
+    def get_indexes(self):
+        """
+        Fills self.indexes with all the indexes associates with the collection and returns it
+        """
         url = "%s/index" % self.database.URL
-        r = self.connection.session.get(url, params = {"collection": self.name})
-        data = r.json()
-        for ind in data["indexes"] :
+        response = self.connection.session.get(url, params = {"collection": self.name})
+        data = response.json()
+        for ind in data["indexes"]:
             self.indexes[ind["type"]][ind["id"]] = Index(collection = self, infos = ind)
 
         return self.indexes
 
-    def activateCache(self, cacheSize) :
-        """Activate the caching system. Cached documents are only available through the __getitem__ interface"""
-        self.documentCache = DocumentCache(cacheSize)
+    def activate_cache(self, cache_size):
+        """
+        Activate the caching system. Cached documents are only available through the __getitem__ interface
+        """
+        self.document_cache = DocumentCache(cache_size)
 
-    def deactivateCache(self) :
+    def deactivate_cache(self):
         "deactivate the caching system"
-        self.documentCache = None
+        self.document_cache = None
 
-    def delete(self) :
-        """deletes the collection from the database"""
-        r = self.connection.session.delete(self.URL)
-        data = r.json()
-        if not r.status_code == 200 or data["error"] :
-            raise DeletionError(data["errorMessage"], data)
+    def delete(self):
+        """
+        deletes the collection from the database
+        """
+        response = self.connection.session.delete(self.URL)
+        data = response.json()
+        if not response.status_code == 200 or data["error"]:
+            raise DeletionError(data["error_message"], data)
 
-    def createDocument(self, initDict = None) :
-        """create and returns a document populated with the defaults or with the values in initDict"""
-        if initDict is not None :
-            return self.createDocument_(initDict)
-        else :
-            if self._validation["on_load"] :
+    def create_document(self, init_dict = None):
+        """
+        create and returns a document populated with the 
+        defaults or with the values in init_dict
+        """
+        if init_dict is not None:
+            return self.createDocument_(init_dict)
+        else:
+            if self._validation["on_load"]:
                 self._validation["on_load"] = False
-                return self.createDocument_(self.defaultDocument)
+                return self.create_document_(self.default_document)
                 self._validation["on_load"] = True
-            else :
-                return self.createDocument_(self.defaultDocument)
+            else:
+                return self.create_document_(self.default_document)
 
-    def createDocument_(self, initDict = None) :
-        "create and returns a completely empty document or one populated with initDict"
-        if initDict is None :
+    def create_document_(self, init_dict = None):
+        """
+        Create and returns a completely empty document or one populated with init_dict
+        """
+        if init_dict is None:
             initV = {}
-        else :
-            initV = initDict
+        else:
+            initV = init_dict
 
-        return self.documentClass(self, initV)
+        return self.document_class(self, initV)
 
-    def importBulk(self, data, **addParams):
+    def import_bulk(self, data, **kwargs):
         url = "%s/import" % (self.database.URL)
         payload = json.dumps(data, default=str)
         params = {"collection": self.name, "type": "auto"}
-        params.update(addParams)
-        r = self.connection.session.post(url , params = params, data = payload)
-        data = r.json()
-        if not r.status_code == 201 or data["error"] :
-            raise CreationError(data["errorMessage"], data)
+        params.update(kwargs)
+        response = self.connection.session.post(url , params = params, data = payload)
+        data = response.json()
+        if not response.status_code == 201 or data["error"]:
+            raise CreationError(data["error_message"], data)
         return data
 
-    def exportDocs( self, **data):
+    def export_docs( self, **data):
         url = "%s/export" % (self.database.URL)
         params = {"collection": self.name}
         payload = json.dumps(data)
-        r = self.connection.session.post(url, params = params, data = payload)
-        data = r.json()
-        if not r.status_code == 201 or data["error"] :
-          raise ExportError( data["errorMessage"], data )
-        docs = data['result']
-        return docs
+        response = self.connection.session.post(url, params = params, data = payload)
+        data = response.json()
+        if not response.status_code == 201 or data["error"]:
+          raise ExportError(data["error_message"], data)
+        documents = data['result']
+        return documents
 
-    def ensureHashIndex(self, fields, unique = False, sparse = True, deduplicate = False) :
-        """Creates a hash index if it does not already exist, and returns it"""
+    def ensure_hash_index(self, fields, unique = False, sparse = True, deduplicate = False):
+        """
+        Creates a hash index if it does not already exist, and returns it
+        """
         data = {
-            "type" : "hash",
-            "fields" : fields,
-            "unique" : unique,
-            "sparse" : sparse,
+            "type": "hash",
+            "fields": fields,
+            "unique": unique,
+            "sparse": sparse,
             "deduplicate": deduplicate
         }
-        ind = Index(self, creationData = data)
+        ind = Index(self, creation_data = data)
         self.indexes["hash"][ind.infos["id"]] = ind
         return ind
 
-    def ensureSkiplistIndex(self, fields, unique = False, sparse = True, deduplicate = False) :
-        """Creates a skiplist index if it does not already exist, and returns it"""
+    def ensure_skiplist_index(self, fields, unique = False, sparse = True, deduplicate = False):
+        """
+        Creates a skiplist index if it does not already exist, and returns it
+        """
         data = {
-            "type" : "skiplist",
-            "fields" : fields,
-            "unique" : unique,
-            "sparse" : sparse,
+            "type": "skiplist",
+            "fields": fields,
+            "unique": unique,
+            "sparse": sparse,
             "deduplicate": deduplicate
         }
-        ind = Index(self, creationData = data)
+        ind = Index(self, creation_data = data)
         self.indexes["skiplist"][ind.infos["id"]] = ind
         return ind
 
-    def ensureGeoIndex(self, fields) :
-        """Creates a geo index if it does not already exist, and returns it"""
+    def ensure_geo_index(self, fields):
+        """
+        Creates a geo index if it does not already exist, and returns it
+        """
         data = {
-            "type" : "geo",
-            "fields" : fields,
+            "type": "geo",
+            "fields": fields,
         }
-        ind = Index(self, creationData = data)
+        ind = Index(self, creation_data = data)
         self.indexes["geo"][ind.infos["id"]] = ind
         return ind
 
-    def ensureFulltextIndex(self, fields, minLength = None) :
-        """Creates a fulltext index if it does not already exist, and returns it"""
+    def ensure_fulltext_index(self, fields, min_length = None):
+        """
+        Creates a fulltext index if it does not already exist, and returns it
+        """
         data = {
-            "type" : "fulltext",
-            "fields" : fields,
+            "type": "fulltext",
+            "fields": fields,
         }
-        if minLength is not None :
-            data["minLength"] = minLength
+        if min_length is not None:
+            data["minLength"] = min_length
 
-        ind = Index(self, creationData = data)
+        ind = Index(self, creation_data = data)
         self.indexes["fulltext"][ind.infos["id"]] = ind
         return ind
 
-
-    def validatePrivate(self, field, value) :
-        """validate a private field value"""
-        if field not in self.arangoPrivates :
+    def validate_private(self, field, value):
+        """
+        validate a private field value
+        """
+        if field not in self.arango_privates:
             raise ValueError("%s is not a private field of collection %s" % (field, self))
 
-        if field in self._fields :
+        if field in self._fields:
             self._fields[field].validate(value)
         return True
 
     # @classmethod
-    # def validateField(cls, fieldName, value) :
+    # def validateField(cls, fieldName, value):
     #     """checks if 'value' is valid for field 'fieldName'. If the validation is unsuccessful, raises a SchemaViolation or a ValidationError.
-    #     for nested dicts ex: {address : { street: xxx} }, fieldName can take the form address.street
+    #     for nested dicts ex: {address: { street: xxx} }, fieldName can take the form address.street
     #     """
 
-    #     def _getValidators(cls, fieldName) :
+    #     def _getValidators(cls, fieldName):
     #         path = fieldName.split(".")
     #         v = cls._fields
-    #         for k in path :
-    #             try :
+    #         for k in path:
+    #             try:
     #                 v = v[k]
-    #             except KeyError :
+    #             except KeyError:
     #                 return None
     #         return v
 
     #     field = _getValidators(cls, fieldName)
 
-    #     if field is None :
-    #         if not cls._validation["allow_foreign_fields"] :
+    #     if field is None:
+    #         if not cls._validation["allow_foreign_fields"]:
     #             raise SchemaViolation(cls, fieldName)
-    #     else :
+    #     else:
     #         return field.validate(value)
 
     # @classmethod
-    # def validateDct(cls, dct) :
+    # def validateDct(cls, dct):
     #     "validates a dictionary. The dictionary must be defined such as {field: value}. If the validation is unsuccefull, raises an InvalidDocument"
-    #     def _validate(dct, res, parentsStr="") :
-    #         for k, v in dct.items() :
-    #             if len(parentsStr) == 0 :
+    #     def _validate(dct, res, parentsStr=""):
+    #         for k, v in dct.items():
+    #             if len(parentsStr) == 0:
     #                 ps = k
-    #             else :
+    #             else:
     #                 ps = "%s.%s" % (parentsStr, k)
 
-    #             if type(v) is dict :
+    #             if type(v) is dict:
     #                 _validate(v, res, ps)
-    #             elif k not in cls.arangoPrivates :
-    #                 try :
+    #             elif k not in cls.arangoPrivates:
+    #                 try:
     #                     cls.validateField(ps, v)
     #                 except (ValidationError, SchemaViolation) as e:
     #                     res[k] = str(e)
 
     #     res = {}
     #     _validate(dct, res)
-    #     if len(res) > 0 :
+    #     if len(res) > 0:
     #         raise InvalidDocument(res)
 
     #     return True
 
     @classmethod
-    def hasField(cls, fieldName) :
-        """returns True/False wether the collection has field K in it's schema. Use the dot notation for the nested fields: address.street"""
-        path = fieldName.split(".")
+    def has_field(cls, field_name):
+        """
+        returns True/False wether the collection has field K in it's schema.
+        Use the dot notation for the nested fields: address.street
+        """
+        path = field_name.split(".")
         v = cls._fields
-        for k in path :
-            try :
+        for k in path:
+            try:
                 v = v[k]
-            except KeyError :
+            except KeyError:
                 return False
         return True
 
-    def fetchDocument(self, key, rawResults = False, rev = None) :
-        """Fetches a document from the collection given it's key. This function always goes straight to the db and bypasses the cache. If you
-        want to take advantage of the cache use the __getitem__ interface: collection[key]"""
-        url = "%s/%s/%s" % (self.documentsURL, self.name, key)
-        if rev is not None :
-            r = self.connection.session.get(url, params = {'rev' : rev})
-        else :
-            r = self.connection.session.get(url)
-
-        if r.status_code < 400 :
-            if rawResults :
-                return r.json()
-            return self.documentClass(self, r.json())
-        elif r.status_code == 404 :
-            raise DocumentNotFoundError("Unable to find document with _key: %s" % key, r.json())
-        else :
-            raise DocumentNotFoundError("Unable to find document with _key: %s, response: %s" % (key, r.json()), r.json())
-
-    def fetchByExample(self, exampleDict, batchSize, rawResults = False, **queryArgs) :
-        """exampleDict should be something like {'age' : 28}"""
-        return self.simpleQuery('by-example', rawResults, example = exampleDict, batchSize = batchSize, **queryArgs)
-
-    def fetchFirstExample(self, exampleDict, rawResults = False) :
-        """exampleDict should be something like {'age' : 28}. returns only a single element but still in a SimpleQuery object.
-        returns the first example found that matches the example"""
-        return self.simpleQuery('first-example', rawResults = rawResults, example = exampleDict)
-
-    def fetchAll(self, rawResults = False, **queryArgs) :
-        """Returns all the documents in the collection. You can use the optinal arguments 'skip' and 'limit'::
-
-            fetchAlll(limit = 3, shik = 10)"""
-        return self.simpleQuery('all', rawResults = rawResults, **queryArgs)
-
-    def simpleQuery(self, queryType, rawResults = False, **queryArgs) :
-        """General interface for simple queries. queryType can be something like 'all', 'by-example' etc... everything is in the arango doc.
-        If rawResults, the query will return dictionaries instead of Document objetcs.
+    def fetch_document(self, key, raw_results = False, rev = None):
         """
-        return SimpleQuery(self, queryType, rawResults, **queryArgs)
+        Fetches a document from the collection given it's key. 
+        This function always goes straight to the db and bypasses the cache. If you
+        want to take advantage of the cache use the __getitem__ interface: collection[key]
+        """
+        url = "%s/%s/%s" % (self.documentsURL, self.name, key)
+        if rev is not None:
+            response = self.connection.session.get(url, params = {'rev': rev})
+        else:
+            response = self.connection.session.get(url)
 
-    def action(self, method, action, **params) :
-        """a generic fct for interacting everything that doesn't have an assigned fct"""
+        if response.status_code < 400:
+            if raw_results:
+                return response.json()
+            return self.document_class(self, response.json())
+        elif response.status_code == 404:
+            raise DocumentNotFoundError("Unable to find document with _key: %s" % key, response.json())
+        else:
+            raise DocumentNotFoundError("Unable to find document with _key: %s, response: %s" % (key, response.json()), response.json())
+
+    def fetch_by_example(self, example_dict, batch_size, raw_results = False, **query_args):
+        """
+        example_dict should be something like {'age': 28}
+        """
+        return self.simple_query('by-example', raw_results, example = example_dict, batch_size = batch_size, **query_args)
+
+    def fetch_first_example(self, example_dict, raw_results = False):
+        """
+        example_dict should be something like {'age': 28}. returns only a single element but still in a SimpleQuery object.
+        returns the first example found that matches the example
+        """
+        return self.simple_query('first-example', raw_results = raw_results, example = example_dict)
+
+    def fetch_all(self, raw_results = False, **query_args):
+        """
+        Returns all the documents in the collection. You can use the optinal arguments 'skip' and 'limit'::
+
+            fetchAlll(limit = 3, shik = 10)
+        """
+        return self.simple_query('all', raw_results = raw_results, **query_args)
+
+    def simple_query(self, query_type, raw_results = False, **query_args):
+        """
+        General interface for simple queries. query_type can be something like 'all', 'by-example' etc... everything is in the arango doc.
+        If raw_results, the query will return dictionaries instead of Document objetcs.
+        """
+        return SimpleQuery(self, query_type, raw_results, **query_args)
+
+    def action(self, method, action, **params):
+        """
+        a generic fct for interacting everything that doesn't have an assigned fct
+        """
         fct = getattr(self.connection.session, method.lower())
-        r = fct(self.URL + "/" + action, params = params)
-        return r.json()
+        response = fct(self.URL + "/" + action, params = params)
+        return response.json()
 
-    def bulkSave(self, docs, onDuplicate="error", **params) :
-        """Parameter docs must be either an iterrable of documents or dictionnaries.
+    def bulkSave(self, documents, on_duplicate="error", **params):
+        """
+        Parameter documents must be either an iterrable of documents or dictionnaries.
         This function will return the number of documents, created and updated, and will raise an UpdateError exception if there's at least one error.
-        params are any parameters from arango's documentation"""
+        params are any parameters from arango's documentation
+        """
 
         payload = []
-        for d in docs :
-            if type(d) is dict :
-                payload.append(json.dumps(d, default=str))
-            else :
+        for document in documents:
+            if type(document) is dict:
+                payload.append(json.dumps(document, default=str))
+            else:
                 try:
-                    payload.append(d.toJson())
+                    payload.append(document.toJson())
                 except Exception as e:
-                    payload.append(json.dumps(d.getStore(), default=str))
+                    payload.append(json.dumps(document.getStore(), default=str))
 
         payload = '\n'.join(payload)
 
         params["type"] = "documents"
-        params["onDuplicate"] = onDuplicate
+        params["on_duplicate"] = onDuplicate
         params["collection"] = self.name
         URL = "%s/import" % self.database.URL
 
-        r = self.connection.session.post(URL, params = params, data = payload)
-        data = r.json()
-        if (r.status_code == 201) and "error" not in data :
+        response = self.connection.session.post(URL, params = params, data = payload)
+        data = response.json()
+        if (response.status_code == 201) and "error" not in data:
             return True
-        else :
-            if data["errors"] > 0 :
+        else:
+            if data["errors"] > 0:
                 raise UpdateError("%d documents could not be created" % data["errors"], data)
 
         return data["updated"] + data["created"]
 
-    def bulkImport_json(self, filename, onDuplicate="error", formatType="auto", **params) :
+    def bulkImport_json(self, filename, on_duplicate="error", formatType="auto", **params):
         """bulk import from a file repecting arango's key/value format"""
 
         url = "%s/import" % self.database.URL
-        params["onDuplicate"] = onDuplicate
+        params["on_duplicate"] = onDuplicate
         params["collection"] = self.name
         params["type"] = formatType
         with open(filename) as f:
             data = f.read()
-            r = self.connection.session.post(URL, params = params, data = data)
+            response = self.connection.session.post(URL, params = params, data = data)
 
-            try :
-                errorMessage = "At least: %d errors. The first one is: '%s'\n\n more in <this_exception>.data" % (len(data), data[0]["errorMessage"])
+            try:
+                error_message = "At least: %d errors. The first one is: '%s'\n\n more in <this_exception>.data" % (len(data), data[0]["error_message"])
             except KeyError:
-                raise UpdateError(data['errorMessage'], data)
+                raise UpdateError(data['error_message'], data)
 
-    def bulkImport_values(self, filename, onDuplicate="error", **params) :
-        """bulk import from a file repecting arango's json format"""
+    def bulk_import_values(self, filename, on_duplicate="error", **params):
+        """
+        bulk import from a file repecting arango's json format
+        """
 
         url = "%s/import" % self.database.URL
-        params["onDuplicate"] = onDuplicate
+        params["on_duplicate"] = onDuplicate
         params["collection"] = self.name
         with open(filename) as f:
             data = f.read()
-            r = self.connection.session.post(URL, params = params, data = data)
+            response = self.connection.session.post(URL, params = params, data = data)
 
-            try :
-                errorMessage = "At least: %d errors. The first one is: '%s'\n\n more in <this_exception>.data" % (len(data), data[0]["errorMessage"])
+            try:
+                error_message = "At least: %d errors. The first one is: '%s'\n\n more in <this_exception>.data" % (len(data), data[0]["error_message"])
             except KeyError:
-                raise UpdateError(data['errorMessage'], data)
+                raise UpdateError(data['error_message'], data)
 
-    def truncate(self) :
-        """deletes every document in the collection"""
+    def truncate(self):
+        """
+        deletes every document in the collection
+        """
         return self.action('PUT', 'truncate')
 
-    def empty(self) :
-        """alias for truncate"""
+    def empty(self):
+        """
+        alias for truncate
+        """
         return self.truncate()
 
-    def load(self) :
-        """loads collection in memory"""
+    def load(self):
+        """
+        loads collection in memory
+        """
         return self.action('PUT', 'load')
 
-    def unload(self) :
-        """unloads collection from memory"""
+    def unload(self):
+        """
+        unloads collection from memory
+        """
         return self.action('PUT', 'unload')
 
-    def revision(self) :
-        """returns the current revision"""
+    def revision(self):
+        """
+        returns the current revision
+        """
         return self.action('GET', 'revision')["revision"]
 
-    def properties(self) :
-        """returns the current properties"""
+    def properties(self):
+        """
+        returns the current properties
+        """
         return self.action('GET', 'properties')
 
-    def checksum(self) :
-        """returns the current checksum"""
+    def checksum(self):
+        """
+        returns the current checksum
+        """
         return self.action('GET', 'checksum')["checksum"]
 
-    def count(self) :
-        """returns the number of documents in the collection"""
+    def count(self):
+        """
+        returns the number of documents in the collection
+        """
         return self.action('GET', 'count')["count"]
 
-    def figures(self) :
-        "a more elaborate version of count, see arangodb docs for more infos"
+    def figures(self):
+        """
+        a more elaborate version of count, see arangodb docs for more infos
+        """
         return self.action('GET', 'figures')
 
-    def getType(self) :
-        """returns a word describing the type of the collection (edges or ducments) instead of a number, if you prefer the number it's in self.type"""
-        if self.type == CONST.COLLECTION_DOCUMENT_TYPE :
+    def getType(self):
+        """
+        returns a word describing the type of the collection (edges or ducments) instead of a number, 
+        if you prefer the number it's in self.type
+        """
+        if self.type == CONST.COLLECTION_DOCUMENT_TYPE:
             return "document"
-        elif self.type == CONST.COLLECTION_EDGE_TYPE :
+        elif self.type == CONST.COLLECTION_EDGE_TYPE:
             return "edge"
-        else :
+        else:
             raise ValueError("The collection is of Unknown type %s" % self.type)
 
-    def getStatus(self) :
-        """returns a word describing the status of the collection (loaded, loading, deleted, unloaded, newborn) instead of a number, if you prefer the number it's in self.status"""
-        if self.status == CONST.COLLECTION_LOADING_STATUS :
+    def getStatus(self):
+        """
+        returns a word describing the status of the collection
+        (loaded, loading, deleted, unloaded, newborn) instead of a number, 
+        if you prefer the number it's in self.status
+        """
+        if self.status == CONST.COLLECTION_LOADING_STATUS:
             return "loading"
-        elif self.status == CONST.COLLECTION_LOADED_STATUS :
+        elif self.status == CONST.COLLECTION_LOADED_STATUS:
             return "loaded"
-        elif self.status == CONST.COLLECTION_DELETED_STATUS :
+        elif self.status == CONST.COLLECTION_DELETED_STATUS:
             return "deleted"
-        elif self.status == CONST.COLLECTION_UNLOADED_STATUS :
+        elif self.status == CONST.COLLECTION_UNLOADED_STATUS:
             return "unloaded"
-        elif self.status == CONST.COLLECTION_NEWBORN_STATUS :
+        elif self.status == CONST.COLLECTION_NEWBORN_STATUS:
             return "newborn"
-        else :
+        else:
             raise ValueError("The collection has an Unknown status %s" % self.status)
 
-    def __len__(self) :
-        """returns the number of documents in the collection"""
+    def __len__(self):
+        """
+        returns the number of documents in the collection
+        """
         return self.count()
 
-    def __repr__(self) :
+    def __repr__(self):
         return "ArangoDB collection name: %s, id: %s, type: %s, status: %s" % (self.name, self.id, self.getType(), self.getStatus())
 
-    def __getitem__(self, key) :
-        """returns a document from the cache. If it's not there, fetches it from the db and caches it first. If the cache is not activated this is equivalent to fetchDocument( rawResults=False)"""
-        if self.documentCache is None :
-            return self.fetchDocument(key, rawResults = False)
-        try :
-            return self.documentCache[key]
-        except KeyError :
-            doc = self.fetchDocument(key, rawResults = False)
-            self.documentCache.cache(doc)
-        return doc
-
-    def __contains__(self, key) :
-        """if doc in collection"""
+    def __getitem__(self, key):
+        """
+        Returns a document from the cache. 
+        If it's not there, fetches it from the db and caches it first. 
+        If the cache is not activated this is equivalent to fetch_document( raw_results=False)
+        """
+        if self.document_cache is None:
+            return self.fetch_document(key, raw_results = False)
         try:
-            self.fetchDocument(key, rawResults = False)
+            return self.document_cache[key]
+        except KeyError:
+            document = self.fetch_document(key, raw_results = False)
+            self.document_cache.cache(document)
+        return document
+
+    def __contains__(self, key):
+        """if document in collection"""
+        try:
+            self.fetch_document(key, raw_results = False)
             return True
         except DocumentNotFoundError as e:
             return False
 
-class SystemCollection(Collection) :
-    """for all collections with isSystem = True"""
-    def __init__(self, database, jsonData) :
+
+class SystemCollection(Collection):
+    """
+    for all collections with isSystem = True
+    """
+    def __init__(self, database, jsonData):
         Collection.__init__(self, database, jsonData)
 
-class Edges(Collection) :
-    """The default edge collection. All edge Collections must inherit from it"""
 
-    arangoPrivates = ["_id", "_key", "_rev", "_to", "_from"]
+class Edges(Collection):
+    """
+    The default edge collection. All edge Collections must inherit from it
+    """
 
-    def __init__(self, database, jsonData) :
-        """This one is meant to be called by the database"""
+    arango_privates = ["_id", "_key", "_rev", "_to", "_from"]
+
+    def __init__(self, database, jsonData):
+        """
+        This one is meant to be called by the database
+        """
         Collection.__init__(self, database, jsonData)
-        self.documentClass = Edge
+        self.document_class = Edge
         self.edgesURL = "%s/edges/%s" % (self.database.URL, self.name)
 
     @classmethod
-    def validateField(cls, fieldName, value) :
-        """checks if 'value' is valid for field 'fieldName'. If the validation is unsuccessful, raises a SchemaViolation or a ValidationError.
-        for nested dicts ex: {address : { street: xxx} }, fieldName can take the form address.street
+    def validate_field(cls, field_name, value):
+        """checks if 'value' is valid for field 'fieldName'. 
+        If the validation is unsuccessful, raises a SchemaViolation or a ValidationError.
+        for nested dicts ex: {address: { street: xxx} }, fieldName can take the form address.street
         """
-        try :
-            valValue = Collection.validateField(fieldName, value)
+        try:
+            validated_value = Collection.validate_field(field_name, value)
         except SchemaViolation as e:
-            if fieldName == "_from" or fieldName == "_to" :
+            if field_name == "_from" or field_name == "_to":
                 return True
-            else :
+            else:
                 raise e
-        return valValue
+        return validated_value
 
-    def createEdge(self) :
-        """Create an edge populated with defaults"""
-        return self.createDocument()
+    def create_edge(self):
+        """
+        Create an edge populated with defaults
+        """
+        return self.create_document()
 
-    def createEdge_(self, initValues = None) :
-        """Create an edge populated with initValues"""
-        if not initValues:
-            initValues = {}
-        return self.createDocument_(initValues)
+    def create_edge_(self, init_values = None):
+        """
+        Create an edge populated with initValues
+        """
+        if not init_values:
+            init_values = {}
+        return self.create_document_(init_values)
 
-    def getInEdges(self, vertex, rawResults = False) :
-        """An alias for getEdges() that returns only the in Edges"""
-        return self.getEdges(vertex, inEdges = True, outEdges = False, rawResults = rawResults)
+    def get_in_edges(self, vertex, raw_results = False):
+        """
+        An alias for get_edges() that returns only the in Edges
+        """
+        return self.getEdges(vertex, in_edges = True, out_edges = False, raw_results = raw_results)
 
-    def getOutEdges(self, vertex, rawResults = False) :
-        """An alias for getEdges() that returns only the out Edges"""
-        return self.getEdges(vertex, inEdges = False, outEdges = True, rawResults = rawResults)
+    def get_out_edges(self, vertex, raw_results = False):
+        """
+        An alias for get_edges() that returns only the out Edges
+        """
+        return self.get_edges(vertex, in_edges = False, out_edges = True, raw_results = raw_results)
 
-    def getEdges(self, vertex, inEdges = True, outEdges = True, rawResults = False) :
-        """returns in, out, or both edges liked to a given document. vertex can be either a Document object or a string for an _id.
-        If rawResults a arango results will be return as fetched, if false, will return a liste of Edge objects"""
+    def get_edges(self, vertex, in_edges = True, out_edges = True, raw_results = False):
+        """
+        returns in, out, or both edges liked to a given document. 
+        Vertex can be either a Document object or a string for an _id.
+        If raw_results a arango results will be return as fetched, 
+        if false, will return a liste of Edge objects
+        """
         if isinstance(vertex, Document):
-            vId = vertex._id
+            vertex_id = vertex._id
         elif (type(vertex) is str) or (type(vertex) is bytes):
-            vId = vertex
-        else :
+            vertex_id = vertex
+        else:
             raise ValueError("Vertex is neither a Document nor a String")
 
-        params = {"vertex" : vId}
-        if inEdges and outEdges :
+        params = {"vertex": vertex_id}
+        if in_edges and out_edges:
             pass
-        elif inEdges :
+        elif in_edges:
             params["direction"] = "in"
-        elif outEdges :
+        elif out_edges:
             params["direction"] = "out"
-        else :
-            raise ValueError("inEdges, outEdges or both must have a boolean value")
+        else:
+            raise ValueError("in_edges, out_edges or both must have a boolean value")
 
-        r = self.connection.session.get(self.edgesURL, params = params)
-        data = r.json()
-        if r.status_code == 200 :
-            if not rawResults :
+        response = self.connection.session.get(self.edgesURL, params = params)
+        data = response.json()
+        if response.status_code == 200:
+            if not raw_results:
                 ret = []
-                for e in data["edges"] :
-                    ret.append(Edge(self, e))
+                for edge in data["edges"]:
+                    ret.append(Edge(self, edge))
                 return ret
-            else :
+            else:
                 return data["edges"]
-        else :
-            raise CreationError("Unable to return edges for vertex: %s" % vId, data)
+        else:
+            raise CreationError("Unable to return edges for vertex: %s" % vertex_id, data)

--- a/pyArango/database.py
+++ b/pyArango/database.py
@@ -233,7 +233,7 @@ class Database(object):
                 self[collection_name].delete()
         return
 
-    def AQLQuery(self, query, batchSize = 100, raw_results = False, bind_variables = {}, options = {}, count = False, fullCount = False,
+    def AQLQuery(self, query, batch_size = 100, raw_results = False, bind_variables = {}, options = {}, count = False, full_count = False,
                  json_encoder = None, **moreArgs) :
         """
         Set raw_results = True if you want the query to 
@@ -245,10 +245,10 @@ class Database(object):
                 self,
                 query,
                 raw_results=raw_results,
-                batchSize=batchSize,
+                batch_size=batch_size,
                 bind_variables=bind_variables,
                 options=options, count=count,
-                fullCount=fullCount,
+                full_count=full_count,
                 json_encoder=json_encoder,
                 **moreArgs
                 )

--- a/pyArango/database.py
+++ b/pyArango/database.py
@@ -95,9 +95,8 @@ class Database(object):
         self.reload_collections()
         self.reload_graphs()
 
-    def create_collection(self, class_name = 'Collection', **collection_properties):
-        """
-        Creates a collection and returns it.
+    def create_collection(self, class_name='Collection', **collection_properties):
+        """Creates a collection and returns it.
         class_name the name of a class inheriting from Collection or Egdes, 
         it can also be set to 'Collection' or 'Edges' in order to create 
         untyped collections of documents or edges.
@@ -149,7 +148,7 @@ class Database(object):
         split_id = _id.split("/")
         return self[split_id[0]][split_id[1]]
 
-    def create_graph(self, name, create_collections = True, is_smart = False, number_of_shards = None, smart_graph_attribute = None) :
+    def create_graph(self, name, create_collections=True, is_smart=False, number_of_shards=None, smart_graph_attribute=None) :
         """
         Creates a graph and returns it. 'name' must be the name 
         of a class inheriting from Graph.

--- a/pyArango/document.py
+++ b/pyArango/document.py
@@ -1,444 +1,514 @@
 import json, types
 from .theExceptions import (CreationError, DeletionError, UpdateError, ValidationError, SchemaViolation, InvalidDocument)
 
+
 __all__ = ["DocumentStore", "Document", "Edge"]
 
-class DocumentStore(object) :
-    """Store all the data of a document in hierarchy of stores and handles validation.
-    Does not store private information, these are in the document."""
 
-    def __init__(self, collection, validators={}, initDct={}, patch=False, subStore=False, validateInit=False) :
+class DocumentStore(object):
+    """
+    Store all the data of a document in hierarchy of stores and handles validation.
+    Does not store private information, these are in the document.
+    """
+
+    def __init__(self, collection, validators={}, initialisation_dictionary={}, patching=False, sub_store=False, validate_init=False):
         self.store = {}
-        self.patchStore = {}
+        self.patch_store = {}
         self.collection = collection
         self.validators = validators
-        self.validateInit = validateInit
-        self.isSubStore = subStore
-        self.subStores = {}
-        self.patching = patch
+        self.validate_init = validate_init
+        self.is_sub_store = sub_store
+        self.sub_stores = {}
+        self.patching = patching
 
-        self.mustValidate = False
-        if not self.validateInit :
-            self.set(initDct)
+        self.must_validate = False
+        if not self.validate_init:
+            self.set(initialisation_dictionary)
 
-        for v in self.collection._validation.values() :
-            if v :
-                self.mustValidate = True
+        for value in self.collection._validation.values():
+            if value:
+                self.must_validate = True
                 break
 
-        if self.validateInit :
-            self.set(initDct)
+        if self.validate_init:
+            self.set(initialisation_dictionary)
         
         self.patching = True
 
-    def resetPatch(self) :
-        """reset patches"""
-        self.patchStore = {}
+    def reset_patch(self):
+        """
+        reset patches
+        """
+        self.patch_store = {}
 
-    def getPatches(self) :
-        """get patches as a dictionary"""
-        if not self.mustValidate :
-            return self.getStore()
+    def get_patches(self):
+        """
+        Get patches as a dictionary
+        """
+        if not self.must_validate:
+            return self.get_store()
 
-        res = {}
-        res.update(self.patchStore)
-        for k, v in self.subStores.items() :
-            res[k] = v.getPatches()
+        result = {}
+        result.update(self.patch_store)
+        for k, v in self.sub_stores.items():
+            result[k] = v.get_patches()
         
-        return res
+        return result
         
-    def getStore(self) :
-        """get the inner store as dictionary"""
+    def get_store(self):
+        """
+        Get the inner store as dictionary
+        """
         res = {}
         res.update(self.store)
-        for k, v in self.subStores.items() :
-            res[k] = v.getStore()
+        for k, v in self.sub_stores.items():
+            res[k] = v.get_store()
         
         return res
 
-    def validateField(self, field) :
-        """Validatie a field"""
-        if field not in self.validators and not self.collection._validation['allow_foreign_fields'] :
+    def validateField(self, field):
+        """
+        Validatie a field
+        """
+        if field not in self.validators and not self.collection._validation['allow_foreign_fields']:
             raise SchemaViolation(self.collection.__class__, field)
 
         if field in self.store:
-            if isinstance(self.store[field], DocumentStore) :
+            if isinstance(self.store[field], DocumentStore):
                 return self[field].validate()
             
-            if field in self.patchStore :
-                return self.validators[field].validate(self.patchStore[field])
-            else :
-                try :
+            if field in self.patch_store:
+                return self.validators[field].validate(self.patch_store[field])
+            else:
+                try:
                     return self.validators[field].validate(self.store[field])
                 except ValidationError as e:
                     raise ValidationError( "'%s' -> %s" % ( field, str(e)) )
                 except AttributeError:
-                    if isinstance(self.validators[field], dict) and not isinstance(self.store[field], dict) :
+                    if isinstance(self.validators[field], dict) and not isinstance(self.store[field], dict):
                         raise ValueError("Validator expected a sub document for field '%s', got '%s' instead" % (field, self.store[field]) )
-                    else :
+                    else:
                         raise
         return True
 
-    def validate(self) :
-        """Validate the whole document"""
-        if not self.mustValidate :
+    def validate(self):
+        """
+        Validate the whole document
+        """
+        if not self.must_validate:
             return True
 
         res = {}
-        for field in self.validators.keys() :
-            try :
-                if isinstance(self.validators[field], dict) and field not in self.store :
-                    self.store[field] = DocumentStore(self.collection, validators = self.validators[field], initDct = {}, subStore=True, validateInit=self.validateInit)
+        for field in self.validators.keys():
+            try:
+                if isinstance(self.validators[field], dict) and field not in self.store:
+                    self.store[field] = DocumentStore(self.collection, validators = self.validators[field], initialisation_dictionary = {}, sub_store=True, validate_initialisation=self.validate_initialisation)
                 self.validateField(field)
-            except InvalidDocument as e :
+            except InvalidDocument as e:
                 res.update(e.errors)
             except (ValidationError, SchemaViolation) as e:
                 res[field] = str(e)
 
-        if len(res) > 0 :
+        if len(res) > 0:
             raise InvalidDocument(res)
         
         return True
 
-    def set(self, dct) :
-        """Set the store using a dictionary"""
-        # if not self.mustValidate :
+    def set(self, dct):
+        """
+        Set the store using a dictionary
+        """
+        # if not self.must_validate:
         #     self.store = dct
-        #     self.patchStore = dct
+        #     self.patch_store = dct
         #     return
 
-        for field, value in dct.items() :
-            if field not in self.collection.arangoPrivates :
-                if isinstance(value, dict) :
+        for field, value in dct.items():
+            if field not in self.collection.arango_privates:
+                if isinstance(value, dict):
                     if field in self.validators and isinstance(self.validators[field], dict):
                         vals = self.validators[field]
-                    else :
+                    else:
                         vals = {}
-                    self[field] = DocumentStore(self.collection, validators = vals, initDct = value, patch = self.patching, subStore=True, validateInit=self.validateInit)
-                    self.subStores[field] = self.store[field]
-                else :
+                    self[field] = DocumentStore(self.collection, validators = vals, initialisation_dictionary = value, patch = self.patching, sub_store=True, validate_initialisation=self.validate_initialisation)
+                    self.sub_stores[field] = self.store[field]
+                else:
                     self[field] = value
 
-    def __getitem__(self, field) :
-        """Get an element from the store"""
-        if (field in self.validators) and isinstance(self.validators[field], dict) and (field not in self.store) :
-            self.store[field] = DocumentStore(self.collection, validators = self.validators[field], initDct = {}, patch = self.patching, subStore=True, validateInit=self.validateInit)
-            self.subStores[field] = self.store[field]
-            self.patchStore[field] = self.store[field]
+    def __getitem__(self, field):
+        """
+        Get an element from the store
+        """
+        if (field in self.validators) and isinstance(self.validators[field], dict) and (field not in self.store):
+            self.store[field] = DocumentStore(self.collection, validators = self.validators[field], initialisation_dictionary = {}, patch = self.patching, sub_store=True, validate_initialisation=self.validate_initialisation)
+            self.sub_stores[field] = self.store[field]
+            self.patch_store[field] = self.store[field]
 
-        if self.collection._validation['allow_foreign_fields'] or self.collection.hasField(field) :
+        if self.collection._validation['allow_foreign_fields'] or self.collection.has_field(field):
             return self.store.get(field)
 
-        try :
+        try:
             return self.store[field]
-        except KeyError :
+        except KeyError:
             raise SchemaViolation(self.collection.__class__, field)
 
-    def __setitem__(self, field, value) :
-        """Set an element in the store"""
-        if (not self.collection._validation['allow_foreign_fields']) and (field not in self.validators) and (field not in self.collection.arangoPrivates):
+    def __setitem__(self, field, value):
+        """
+        Set an element in the store
+        """
+        if (not self.collection._validation['allow_foreign_fields']) and (field not in self.validators) and (field not in self.collection.arango_privates):
             raise SchemaViolation(self.collection.__class__, field)
         
-        if field in self.collection.arangoPrivates :
+        if field in self.collection.arango_privates:
             raise ValueError("DocumentStore cannot contain private field (got %s)" % field)
 
-        if isinstance(value, dict) :
+        if isinstance(value, dict):
             if field in self.validators and isinstance(self.validators[field], dict):
                 vals = self.validators[field]
-            else :
+            else:
                 vals = {}
-            self.store[field] = DocumentStore(self.collection, validators = vals, initDct = value, patch = self.patching, subStore=True, validateInit=self.validateInit)
+            self.store[field] = DocumentStore(self.collection, validators = vals, initialisation_dictionary = value, patch = self.patching, sub_store=True, validate_initialisation=self.validate_initialisation)
             
-            self.subStores[field] = self.store[field]
-        else :
+            self.sub_stores[field] = self.store[field]
+        else:
             self.store[field] = value
 
-        if self.patching :
-            self.patchStore[field] = self.store[field]
+        if self.patching:
+            self.patch_store[field] = self.store[field]
 
-        if self.mustValidate and self.collection._validation['on_set'] :
+        if self.must_validate and self.collection._validation['on_set']:
             self.validateField(field)
 
-    def __delitem__(self, k) :
-        """removes an element from the store"""
-        try :
+    def __delitem__(self, k):
+        """
+        removes an element from the store
+        """
+        try:
             del(self.store[k])
-        except :
+        except:
             pass
     
-        try :
-            del(self.patchStore[k])
-        except :
+        try:
+            del(self.patch_store[k])
+        except:
             pass
 
-    def __contains__(self, k) :
-        """returns true or false weither the store has a key k"""
+    def __contains__(self, k):
+        """
+        Returns true or false weither the store has a key k
+        """
         return (k in self.store) or (k in self.validators)
 
-    def __repr__(self) :
+    def __repr__(self):
         return "<store: %s>" % repr(self.store)
 
-class Document(object) :
-    """The class that represents a document. Documents are meant to be instanciated by collections"""
+class Document(object):
+    """
+    The class that represents a document. Documents are meant to be instanciated by collections
+    """
 
-    def __init__(self, collection, jsonFieldInit = None) :
-        if jsonFieldInit is None :
-            jsonFieldInit = {}
+    def __init__(self, collection, json_field_init = None):
+        if json_field_init is None:
+            json_field_init = {}
         self.privates = ["_id", "_key", "_rev"]
-        self.reset(collection, jsonFieldInit)
-        self.typeName = "ArangoDoc"
+        self.reset(collection, json_field_init)
+        self.type_name = "ArangoDoc"
 
-    def reset(self, collection, jsonFieldInit = None) :
-        if not jsonFieldInit:
-            jsonFieldInit = {}
-        """replaces the current values in the document by those in jsonFieldInit"""
+    def reset(self, collection, json_field_init = None):
+        if not json_field_init:
+            json_field_init = {}
+        """
+        Replaces the current values in the document by those in json_field_init
+        """
         self.collection = collection
         self.connection = self.collection.connection
         self.documentsURL = self.collection.documentsURL
 
 
         self.URL = None
-        self.setPrivates(jsonFieldInit)
-        self._store = DocumentStore(self.collection, validators=self.collection._fields, initDct=jsonFieldInit)
+        self.set_privates(json_field_init)
+        self._store = DocumentStore(self.collection, validators=self.collection._fields, initialisation_dictionary=json_field_init)
         if self.collection._validation['on_load']:
             self.validate()
 
         self.modified = True
 
-    def validate(self) :
-        """validate the document"""
+    def validate(self):
+        """
+        validate the document
+        """
         self._store.validate()
-        for pField in self.collection.arangoPrivates :
-            self.collection.validatePrivate(pField, getattr(self, pField))
+        for pField in self.collection.arango_privates:
+            self.collection.validate_private(pField, getattr(self, pField))
 
-    def setPrivates(self, fieldDict) :
-        """will set self._id, self._rev and self._key field."""
+    def set_privates(self, field_dict):
+        """
+        will set self._id, self._rev and self._key field.
+        """
         
-        for priv in self.privates :
-            if priv in fieldDict :
-                setattr(self, priv, fieldDict[priv])
-            else :
-                setattr(self, priv, None)
+        for private in self.privates:
+            if private in field_dict:
+                setattr(self, private, field_dict[private])
+            else:
+                setattr(self, private, None)
         
-        if self._id is not None :
+        if self._id is not None:
             self.URL = "%s/%s" % (self.documentsURL, self._id)
 
-    def set(self, fieldDict) :
-        """set the document with a dictionary"""
-        self._store.set(fieldDict)
+    def set(self, field_dict):
+        """
+        set the document with a dictionary
+        """
+        self._store.set(field_dict)
 
-    def save(self, waitForSync = False, **docArgs) :
-        """Saves the document to the database by either performing a POST (for a new document) or a PUT (complete document overwrite).
+    def save(self, wait_for_sync = False, **document_args):
+        """
+        Saves the document to the database by either performing a POST (for a new document) or a PUT (complete document overwrite).
         If you want to only update the modified fields use the .patch() function.
-        Use docArgs to put things such as 'waitForSync = True' (for a full list cf ArangoDB's doc).
-        It will only trigger a saving of the document if it has been modified since the last save. If you want to force the saving you can use forceSave()"""
-        payload = self._store.getStore()
-        self._save(payload, waitForSync = False, **docArgs)
+        Use document_args to put things such as 'wait_for_sync = True' (for a full list cf ArangoDB's doc).
+        It will only trigger a saving of the document if it has been modified since the last save. If you want to force the saving you can use force_save()
+        """
+        payload = self._store.get_store()
+        self._save(payload, wait_for_sync = False, **document_args)
 
-    def _save(self, payload, waitForSync = False, **docArgs) :
+    def _save(self, payload, wait_for_sync = False, **document_args):
 
-        if self.modified :
+        if self.modified:
 
-            params = dict(docArgs)
-            params.update({'collection': self.collection.name, "waitForSync" : waitForSync })
+            params = dict(document_args)
+            params.update({'collection': self.collection.name, "wait_for_sync": wait_for_sync })
 
-            if self.collection._validation['on_save'] :
+            if self.collection._validation['on_save']:
                 self.validate()
-            if self.URL is None :
-                if self._key is not None :
+            if self.URL is None:
+                if self._key is not None:
                     payload["_key"] = self._key
                 payload = json.dumps(payload, default=str)
-                r = self.connection.session.post(self.documentsURL, params = params, data = payload)
+                response = self.connection.session.post(self.documentsURL, params = params, data = payload)
                 update = False
                 data = r.json()
-                self.setPrivates(data)
-            else :
+                self.set_privates(data)
+            else:
                 payload = json.dumps(payload, default=str)
-                r = self.connection.session.put(self.URL, params = params, data = payload)
+                response = self.connection.session.put(self.URL, params = params, data = payload)
                 update = True
-                data = r.json()
+                data = response.json()
 
 
-            if (r.status_code == 201 or r.status_code == 202) and "error" not in data :
-                if update :
+            if (response.status_code == 201 or response.status_code == 202) and "error" not in data:
+                if update:
                     self._rev = data['_rev']
-                else :
+                else:
                     self.set(data)
-            else :
-                if update :
+            else:
+                if update:
                     raise UpdateError(data['errorMessage'], data)
-                else :
+                else:
                     raise CreationError(data['errorMessage'], data)
 
             self.modified = False
 
-        self._store.resetPatch()
+        self._store.reset_patch()
 
-    def forceSave(self, **docArgs) :
-        "saves even if the document has not been modified since the last save"
+    def force_save(self, **document_args):
+        """
+        saves even if the document has not been modified since the last save
+        """
         self.modified = True
-        self.save(**docArgs)
+        self.save(**document_args)
 
-    def saveCopy(self) :
-        "saves a copy of the object and become that copy. returns a tuple (old _key, new _key)"
+    def save_copy(self):
+        """
+        saves a copy of the object and become that copy. returns a tuple (old _key, new _key)
+        """
         old_key = self._key
         self.reset(self.collection)
         self.save()
         return (old_key, self._key)
 
-    def patch(self, keepNull = True, **docArgs) :
-        """Saves the document by only updating the modified fields.
+    def patch(self, keepNull = True, **document_args):
+        """
+        Saves the document by only updating the modified fields.
         The default behaviour concening the keepNull parameter is the opposite of ArangoDB's default, Null values won't be ignored
-        Use docArgs for things such as waitForSync = True"""
+        Use document_args for things such as wait_for_sync = True
+        """
 
-        if self.URL is None :
+        if self.URL is None:
             raise ValueError("Cannot patch a document that was not previously saved")
 
-        payload = self._store.getPatches()
+        payload = self._store.get_patches()
         
-        if self.collection._validation['on_save'] :
+        if self.collection._validation['on_save']:
             self.validate()
 
-        if len(payload) > 0 :
-            params = dict(docArgs)
-            params.update({'collection': self.collection.name, 'keepNull' : keepNull})
+        if len(payload) > 0:
+            params = dict(document_args)
+            params.update({'collection': self.collection.name, 'keepNull': keepNull})
             payload = json.dumps(payload, default=str)
 
-            r = self.connection.session.patch(self.URL, params = params, data = payload)
-            data = r.json()
-            if (r.status_code == 201 or r.status_code == 202) and "error" not in data :
+            response = self.connection.session.patch(self.URL, params = params, data = payload)
+            data = response.json()
+            if (response.status_code == 201 or response.status_code == 202) and "error" not in data:
                 self._rev = data['_rev']
-            else :
+            else:
                 raise UpdateError(data['errorMessage'], data)
 
             self.modified = False
 
-        self._store.resetPatch()
+        self._store.reset_patch()
 
-    def delete(self) :
-        "deletes the document from the database"
-        if self.URL is None :
+    def delete(self):
+        """
+        deletes the document from the database
+        """
+        if self.URL is None:
             raise DeletionError("Can't delete a document that was not saved")
-        r = self.connection.session.delete(self.URL)
-        data = r.json()
+        response = self.connection.session.delete(self.URL)
+        data = response.json()
 
-        if (r.status_code != 200 and r.status_code != 202) or 'error' in data :
+        if (response.status_code != 200 and response.status_code != 202) or 'error' in data:
             raise DeletionError(data['errorMessage'], data)
         self.reset(self.collection)
 
         self.modified = True
 
-    def getInEdges(self, edges, rawResults = False) :
-        "An alias for getEdges() that returns only the in Edges"
-        return self.getEdges(edges, inEdges = True, outEdges = False, rawResults = rawResults)
+    def get_in_edges(self, edges, raw_results = False):
+        """
+        An alias for get_edges() that returns only the in Edges
+        """
+        return self.get_edges(edges, in_edges = True, out_edges = False, raw_results = raw_results)
 
-    def getOutEdges(self, edges, rawResults = False) :
-        "An alias for getEdges() that returns only the out Edges"
-        return self.getEdges(edges, inEdges = False, outEdges = True, rawResults = rawResults)
+    def get_out_edges(self, edges, raw_results = False):
+        """
+        An alias for get_edges() that returns only the out Edges
+        """
+        return self.get_edges(edges, in_edges = False, out_edges = True, raw_results = raw_results)
 
-    def getEdges(self, edges, inEdges = True, outEdges = True, rawResults = False) :
-        """returns in, out, or both edges linked to self belonging the collection 'edges'.
-        If rawResults a arango results will be return as fetched, if false, will return a liste of Edge objects"""
-        try :
-            return edges.getEdges(self, inEdges, outEdges, rawResults)
-        except AttributeError :
+    def get_edges(self, edges, in_edges = True, out_edges = True, raw_results = False):
+        """
+        returns in, out, or both edges linked to self belonging the collection 'edges'.
+        If raw_results a arango results will be return as fetched, if false, 
+        will return a liste of Edge objects
+        """
+        try:
+            return edges.get_edges(self, in_edges, out_edges, raw_results)
+        except AttributeError:
             raise AttributeError("%s does not seem to be a valid Edges object" % edges)
 
-    def getStore(self) :
-        """return the store in a dict format"""
-        store = self._store.getStore()
-        for priv in self.privates :
-            v = getattr(self, priv)
-            if v :
-                store[priv] = v
+    def get_store(self):
+        """
+        return the store in a dict format
+        """
+        store = self._store.get_store()
+        for private in self.privates:
+            v = getattr(self, private)
+            if v:
+                store[private] = v
         return store
 
-    def getPatches(self) :
-        """return the patches in a dict format"""
-        return self._store.getPatches()
-
-    def __getitem__(self, k) :
-        """get an element from the document"""
-        if k in self.collection.arangoPrivates :
+    def get_patches(self):
+        """
+        return the patches in a dict format
+        """
+        return self._store.get_patches()
+        """
+        get an element from the document
+        """
+        if k in self.collection.arango_privates:
             return getattr(self, k)
         return self._store[k]
 
-    def __setitem__(self, k, v) :
-        """set an element in the document"""
-        if k in self.collection.arangoPrivates :
+    def __setitem__(self, k, v):
+        """
+        set an element in the document
+        """
+        if k in self.collection.arango_privates:
             setattr(self, k, v)
-        else :
+        else:
             self._store[k] = v
 
-    def __delitem__(self, k) :
-        """removes an element from the document"""
+    def __delitem__(self, k):
+        """
+        removes an element from the document
+        """
         del(self._store[k])
     
-    def __str__(self) :
+    def __str__(self):
         return repr(self)
 
-    def __repr__(self) :
-        privStr = []
-        for p in self.collection.arangoPrivates :
-            privStr.append("%s: %s" % (p, getattr(self, p)) )
+    def __repr__(self):
+        private_string = []
+        for p in self.collection.arango_privates:
+            private_string.append("%s: %s" % (p, getattr(self, p)) )
 
-        privStr = ', '.join(privStr)
-        return "%s '%s': %s" % (self.typeName, privStr, repr(self._store))
+        private_string = ', '.join(private_string)
+        return "%s '%s': %s" % (self.type_name, private_string, repr(self._store))
 
-class Edge(Document) :
-    """An Edge document"""
-    def __init__(self, edgeCollection, jsonFieldInit = None) :
-        if not jsonFieldInit:
-            jsonFieldInit = {}
+
+class Edge(Document):
+    """
+    An Edge document
+    """
+    def __init__(self, edge_collection, json_field_init = None):
+        if not json_field_init:
+            json_field_init = {}
             
-        self.typeName = "ArangoEdge"
+        self.type_name = "ArangoEdge"
         self.privates = ["_id", "_key", "_rev", "_from", "_to"]
-        self.reset(edgeCollection, jsonFieldInit)
+        self.reset(edge_collection, json_field_init)
 
-    def reset(self, edgeCollection, jsonFieldInit = None) :
-        if jsonFieldInit is None:
-            jsonFieldInit = {}
-        Document.reset(self, edgeCollection, jsonFieldInit)
+    def reset(self, edge_collection, json_field_init = None):
+        if json_field_init is None:
+            json_field_init = {}
+        Document.reset(self, edge_collection, json_field_init)
 
-    def links(self, fromVertice, toVertice, **edgeArgs) :
+    def links(self, from_vertice, to_vertice, **edge_args):
         """
         An alias to save that updates the _from and _to attributes.
-        fromVertice and toVertice, can be either strings or documents. It they are unsaved documents, they will be automatically saved.
+        from_vertice and to_vertice, can be either strings or documents. It they are unsaved documents, they will be automatically saved.
         """
-        if isinstance(fromVertice, Document) or isinstance(getattr(fromVertice, 'document', None), Document):
-            if not fromVertice._id :
-                fromVertice.save()
-            self._from = fromVertice._id
-        elif (type(fromVertice) is bytes) or (type(fromVertice) is str):
-            self._from  = fromVertice
+        if isinstance(from_vertice, Document) or isinstance(getattr(from_vertice, 'document', None), Document):
+            if not from_vertice._id:
+                from_vertice.save()
+            self._from = from_vertice._id
+        elif (type(from_vertice) is bytes) or (type(from_vertice) is str):
+            self._from  = from_vertice
         elif not self._from:
-            raise CreationError('fromVertice %s is invalid!' % str(fromVertice))
+            raise CreationError('from_vertice %s is invalid!' % str(from_vertice))
         
-        if isinstance(toVertice, Document) or isinstance(getattr(toVertice, 'document', None), Document):
-            if not toVertice._id:
-                toVertice.save()
-            self._to = toVertice._id
-        elif (type(toVertice) is bytes) or (type(toVertice) is str):
-            self._to = toVertice
+        if isinstance(to_vertice, Document) or isinstance(getattr(to_vertice, 'document', None), Document):
+            if not to_vertice._id:
+                to_vertice.save()
+            self._to = to_vertice._id
+        elif (type(to_vertice) is bytes) or (type(to_vertice) is str):
+            self._to = to_vertice
         elif not self._to:
-            raise CreationError('toVertice %s is invalid!' % str(toVertice))
+            raise CreationError('to_vertice %s is invalid!' % str(to_vertice))
         
-        self.save(**edgeArgs)
+        self.save(**edge_args)
 
-    def save(self, **edgeArgs) :
-        """Works like Document's except that you must specify '_from' and '_to' vertices before.
-        There's also a links() function especially for first saves."""
+    def save(self, **edge_args):
+        """
+        Works like Document's except that you must 
+        specify '_from' and '_to' vertices before.
+        There's also a links() function especially for first saves.
+        """
 
-        if not getattr(self, "_from") or not getattr(self, "_to") :
-            raise AttributeError("You must specify '_from' and '_to' attributes before saving. You can also use the function 'links()'")
+        print("SAVINGG\n\n\n")
 
-        payload = self._store.getStore()
+        if not getattr(self, "_from") or not getattr(self, "_to"):
+            raise AttributeError(
+                    "You must specify '_from' and '_to' attributes"
+                    "before saving. You can also use the function 'links()'"
+                    )
+
+        payload = self._store.get_store()
         payload["_from"] = self._from
         payload["_to"] = self._to
-        Document._save(self, payload, **edgeArgs)
+        Document._save(self, payload, **edge_args)
 
-    def __getattr__(self, k) :
-        if k == "_from" or k == "_to" :
+    def __getattr__(self, k):
+        if k == "_from" or k == "_to":
             return self._store[k]
-        else :
+        else:
             return Document.__getattr__(self, k)

--- a/pyArango/document.py
+++ b/pyArango/document.py
@@ -66,7 +66,7 @@ class DocumentStore(object):
         
         return res
 
-    def validateField(self, field):
+    def validate_field(self, field):
         """
         Validatie a field
         """
@@ -103,7 +103,7 @@ class DocumentStore(object):
             try:
                 if isinstance(self.validators[field], dict) and field not in self.store:
                     self.store[field] = DocumentStore(self.collection, validators = self.validators[field], initialisation_dictionary = {}, sub_store=True, validate_initialisation=self.validate_initialisation)
-                self.validateField(field)
+                self.validate_field(field)
             except InvalidDocument as e:
                 res.update(e.errors)
             except (ValidationError, SchemaViolation) as e:
@@ -177,7 +177,7 @@ class DocumentStore(object):
             self.patch_store[field] = self.store[field]
 
         if self.must_validate and self.collection._validation['on_set']:
-            self.validateField(field)
+            self.validate_field(field)
 
     def __delitem__(self, k):
         """
@@ -202,9 +202,9 @@ class DocumentStore(object):
     def __repr__(self):
         return "<store: %s>" % repr(self.store)
 
-class Document(object):
+class Document:
     """
-    The class that represents a document. Documents are meant to be instanciated by collections
+    The class that represents a document. Documents are meant to be instanciated by collections.
     """
 
     def __init__(self, collection, json_field_init = None):
@@ -213,6 +213,7 @@ class Document(object):
         self.privates = ["_id", "_key", "_rev"]
         self.reset(collection, json_field_init)
         self.type_name = "ArangoDoc"
+
 
     def reset(self, collection, json_field_init = None):
         if not json_field_init:

--- a/pyArango/graph.py
+++ b/pyArango/graph.py
@@ -47,7 +47,7 @@ class GraphMetaclass(type):
     @classmethod
     def is_graph(cls, name):
         """
-        returns true/false depending if there is a graph called name
+        returns True/False depending if there is a graph called name
         """
         return name in cls.graph_classes
 

--- a/pyArango/index.py
+++ b/pyArango/index.py
@@ -1,36 +1,49 @@
 import json
 from .theExceptions import (CreationError, DeletionError, UpdateError)
 
-class Index(object) :
-    """An index on a collection's fields. Indexes are meant to de created by ensureXXX functions of Collections. 
-Indexes have a .infos dictionary that stores all the infos about the index"""
+class Index(object):
+    """
+    An index on a collection's fields.
+    Indexes are meant to de created by ensure functions of Collections. 
+    Indexes have a .infos dictionary that stores all the infos about the index
+    """
 
-    def __init__(self, collection, infos = None, creationData = None) :
+    def __init__(self, collection, infos = None, creation_data = None):
 
         self.collection = collection
         self.connection = self.collection.database.connection
-        self.indexesURL = "%s/index" % self.collection.database.URL
+        self.indexes_URL = "%s/index" % self.collection.database.URL
         self.infos = None
-        if infos  :
+        if infos:
             self.infos = infos
-        elif creationData :
-            self._create(creationData)
+        elif creation_data:
+            self._create(creation_data)
 
-        if self.infos :
-            self.URL = "%s/%s" % (self.indexesURL, self.infos["id"])
+        if self.infos:
+            self.URL = "%s/%s" % (self.indexes_URL, self.infos["id"])
 
-    def _create(self, postData) :
-        """Creates an index of any type according to postData"""
-        if self.infos is None :
-            r = self.connection.session.post(self.indexesURL, params = {"collection" : self.collection.name}, data = json.dumps(postData, default=str))
-            data = r.json()
-            if (r.status_code >= 400) or data['error'] :
+    def _create(self, post_data):
+        """
+        Creates an index of any type according to post_data
+        """
+        if self.infos is None:
+            response = self.connection.session.post(
+                    self.indexes_URL,
+                    params = {
+                        "collection": self.collection.name
+                        },
+                    data = json.dumps(post_data, default=str))
+            data = response.json()
+            if (response.status_code >= 400) or data['error']:
                 raise CreationError(data['errorMessage'], data)
             self.infos = data
 
-    def delete(self) :
-        """Delete the index"""
-        r = self.connection.session.delete(self.URL)
-        data = r.json()
-        if (r.status_code != 200 and r.status_code != 202) or data['error'] :
+    def delete(self):
+        """
+        Delete the index
+        """
+        response = self.connection.session.delete(self.URL)
+        data = response.json()
+        if (response.status_code != 200 and response.status_code != 202) \
+                or data['error']:
             raise DeletionError(data['errorMessage'], data)

--- a/pyArango/query.py
+++ b/pyArango/query.py
@@ -9,193 +9,224 @@ from . import consts as CONST
 __all__ = ["Query", "AQLQuery", "SimpleQuery", "Cursor", "RawCursor"]
 
 @implements_iterator
-class RawCursor(object) :
-    "a raw interface to cursors that returns json"
-    def __init__(self, database, cursorId) :
+class RawCursor(object):
+    """
+    a raw interface to cursors that returns json
+    """
+
+    def __init__(self, database, cursor_id):
         self.database = database
         self.connection = self.database.connection
-        self.id = cursorId
+        self.id = cursor_id
         self.URL = "%s/cursor/%s" % (self.database.URL, self.id)
 
-    def __next__(self) :
-        "returns the next batch"
-        r = self.connection.session.put(self.URL)
-        data = r.json()
-        if r.status_code in [400, 404] :
+    def __next__(self):
+        """
+        returns the next batch
+        """
+        response = self.connection.session.put(self.URL)
+        data = response.json()
+        if response.status_code in [400, 404]:
             raise CursorError(data["errorMessage"], self.id, data)
-        return r.json()
+        return response.json()
 
 @implements_iterator
-class Query(object) :
-    "This class is abstract and should not be instanciated. All query classes derive from it"
+class Query(object):
+    """
+    This class is abstract and should not be instanciated. All query classes derive from it
+    """
 
-    def __init__(self, request, database, rawResults) :
-        "If rawResults = True, the results will be returned as dictionaries instead of Document objects."
+    def __init__(self, request, database, raw_results):
+        """
+        If raw_results = True, the results will be returned as dictionaries instead of Document objects.
+        """
 
-        self.rawResults = rawResults
+        self.raw_results = raw_results
         self.response = request.json()
-        if self.response.get("error") and self.response["errorMessage"] != "no match" :
+        if self.response.get("error") and self.response["errorMessage"] != "no match":
             raise QueryError(self.response["errorMessage"], self.response)
 
         self.request = request
         self.database = database
         self.connection = self.database.connection
-        self.currI = 0
-        if request.status_code == 201 or request.status_code == 200 or request.status_code == 202 :
+        self.current_i = 0
+        if request.status_code == 201 or request.status_code == 200 or request.status_code == 202:
             self.batchNumber = 1
-            try : #if there's only one element
-                self.response = {"result" : [self.response["document"]], 'hasMore' : False}
+            try: #if there's only one element
+                self.response = {"result": [self.response["document"]], 'hasMore' : False}
                 del(self.response["document"])
-            except KeyError :
+            except KeyError:
                 pass
 
-            if "hasMore" in self.response and self.response["hasMore"] :
+            if "hasMore" in self.response and self.response["hasMore"]:
                 cursor_id = self.response.get("id","")
                 self.cursor = RawCursor(self.database, cursor_id)
-            else :
+            else:
                 self.cursor = None
-        elif request.status_code == 404 :
-            self.batchNumber = 0
+        elif request.status_code == 404:
+            self.batch_number = 0
             self.result = []
-        else :
-            self._raiseInitFailed(request)
+        else:
+            self._raise_init_failed(request)
 
-    def _raiseInitFailed(self, request) :
-        "must be implemented in child, this called if the __init__ fails"
+    def _raise_init_failed(self, request):
+        """
+        must be implemented in child, this called if the __init__ fails
+        """
         raise NotImplemented("Must be implemented in child")
 
-    def _developDoc(self, i) :
-        """private function that transforms a json returned by ArangoDB into a pyArango Document or Edge"""
-        docJson = self.result[i]
-        try :
-            collection = self.database[docJson["_id"].split("/")[0]]
-        except KeyError :
-            raise CreationError("result %d is not a valid Document. Try setting rawResults to True" % i)
+    def _develop_doc(self, i):
+        """
+        private function that transforms a json returned by ArangoDB into a pyArango Document or Edge
+        """
+        doc_json = self.result[i]
+        try:
+            collection = self.database[doc_json["_id"].split("/")[0]]
+        except KeyError:
+            raise CreationError("result %d is not a valid Document. Try setting raw_results to True" % i)
 
-        if collection.type == CONST.COLLECTION_EDGE_TYPE :
-            self.result[i] = Edge(collection, docJson)
-        else :
-            self.result[i] = Document(collection, docJson)
+        if collection.type == CONST.COLLECTION_EDGE_TYPE:
+            self.result[i] = Edge(collection, doc_json)
+        else:
+            self.result[i] = Document(collection, doc_json)
 
-    def nextBatch(self) :
-        "become the next batch. raises a StopIteration if there is None"
-        self.batchNumber += 1
-        self.currI = 0
-        try :
-            if not self.response["hasMore"] or self.cursor is None :
+    def next_batch(self):
+        """
+        become the next batch. raises a StopIteration if there is None
+        """
+        self.batch_number += 1
+        self.current_i = 0
+        try:
+            if not self.response["hasMore"] or self.cursor is None:
                 raise StopIteration("That was the last batch")
-        except KeyError :
+        except KeyError:
             raise AQLQueryError(self.response["errorMessage"], self.query, self.response)
 
         self.response = next(self.cursor)
 
-    def delete(self) :
-        "kills the cursor"
+    def delete(self):
+        """
+        kills the cursor
+        """
         self.connection.session.delete(self.cursor)
 
-    def __next__(self) :
-        """returns the next element of the query result. Automatomatically calls for new batches if needed"""
-        try :
-            v = self[self.currI]
-        except IndexError :
+    def __next__(self):
+        """
+        returns the next element of the query result. Automatomatically calls for new batches if needed
+        """
+        try:
+            v = self[self.current_i]
+        except IndexError:
             self.nextBatch()
-        v = self[self.currI]
-        self.currI += 1
+        v = self[self.current_i]
+        self.current_i += 1
         return v
 
-    def __iter__(self) :
-        """Returns an itererator so you can do::
-
-            for doc in query : print doc
+    def __iter__(self):
+        """
+        Returns an itererator so you can do:
+            for doc in query: print doc
         """
         return self
 
-    def __getitem__(self, i) :
-        "returns a ith result of the query."
-        if not self.rawResults and (not isinstance(self.result[i], (Edge, Document))):
-            self._developDoc(i)
+    def __getitem__(self, i):
+        """
+        returns a ith result of the query.
+        """
+        if not self.raw_results and (not isinstance(self.result[i], (Edge, Document))):
+            self._develop_doc(i)
         return self.result[i]
 
-    def __len__(self) :
-        """Returns the number of elements in the query results"""
+    def __len__(self):
+        """
+        Returns the number of elements in the query results
+        """
         return len(self.result)
 
-    def __getattr__(self, k) :
-        try :
+    def __getattr__(self, k):
+        try:
             resp = object.__getattribute__(self, "response")
             return resp[k]
-        except (KeyError, AttributeError) :
+        except (KeyError, AttributeError):
             raise  AttributeError("There's no attribute %s" %(k))
 
-    def __str__(self) :
+    def __str__(self):
         return str(self.result)
 
-class AQLQuery(Query) :
-    "AQL queries are attached to and instanciated by a database"
-    def __init__(self, database, query, batchSize, bindVars, options, count, fullCount, rawResults = True,
-                 json_encoder = None, **moreArgs) :
+class AQLQuery(Query):
+    """
+    AQL queries are attached to and instanciated by a database
+    """
+    def __init__(self, database, query, batch_size, bind_vars, options, count, full_count, raw_results=True,
+                 json_encoder=None, **more_args):
         # fullCount is passed in the options dict per https://docs.arangodb.com/3.1/HTTP/AqlQueryCursor/AccessingCursors.html
-        options["fullCount"] = fullCount
-        payload = {'query' : query, 'batchSize' : batchSize, 'bindVars' : bindVars, 'options' : options, 'count' : count}
-        payload.update(moreArgs)
+        options["fullCount"] = full_count
+        payload = {'query': query, 'batchSize': batch_size, 'bindVars': bindVars, 'options': options, 'count': count}
+        payload.update(more_args)
 
         self.query = query
         self.database = database
         self.connection = self.database.connection
-        self.connection.reportStart(query)
-        request = self.connection.session.post(database.cursorsURL, data = json.dumps(payload, cls=json_encoder, default=str))
+        self.connection.report_start(query)
+        request = self.connection.session.post(database.cursors_URL, data = json.dumps(payload, cls=json_encoder, default=str))
         self.connection.reportItem()
 
-        try :
-            Query.__init__(self, request, database, rawResults)
+        try:
+            Query.__init__(self, request, database, raw_results)
         except QueryError as e:
             raise AQLQueryError( message = e.message, query = self.query, errors = e.errors)
 
-    def explain(self, bindVars={}, allPlans = False) :
-        """Returns an explanation of the query. Setting allPlans to True will result in ArangoDB returning all possible plans. False returns only the optimal plan"""
-        return self.database.explainAQLQuery(self.query, bindVars, allPlans)
+    def explain(self, bind_vars={}, all_plans=False):
+        """
+        Returns an explanation of the query. Setting allPlans to True will result in ArangoDB returning all possible plans. False returns only the optimal plan
+        """
+        return self.database.explainAQLQuery(self.query, bind_vars, all_plans)
 
-    def _raiseInitFailed(self, request) :
+    def _raiseInitFailed(self, request):
         data = request.json()
         raise AQLQueryError(data["errorMessage"], self.query, data)
 
-class Cursor(Query) :
-    "Cursor queries are attached to and instanciated by a database, use them to continue from where you left"
-    def __init__(self, database, cursorId, rawResults) :
-        self.rawResults = rawResults
+class Cursor(Query):
+    """
+    Cursor queries are attached to and instanciated by a database, use them to continue from where you left
+    """
+    def __init__(self, database, cursor_id, raw_results):
+        self.raw_results = raw_results
         self._developed = set()
-        self.batchNumber = 1
-        self.cursor = RawCursor(database, cursorId)
+        self.batch_number = 1
+        self.cursor = RawCursor(database, cursor_id)
         self.response = next(self.cursor)
 
-    def _raiseInitFailed(self, request) :
+    def _raise_init_failed(self, request):
         data = request.json()
         raise CursorError(data["errorMessage"], self.id, data)
 
 
-class SimpleQuery(Query) :
-    "Simple queries are attached to and instanciated by a collection"
-    def __init__(self, collection, queryType, rawResults, json_encoder = None,
-                 **queryArgs) :
+class SimpleQuery(Query):
+    """
+    Simple queries are attached to and instanciated by a collection
+    """
+    def __init__(self, collection, query_type, raw_results, json_encoder = None,
+                 **query_args):
 
         self.collection = collection
         self.connection = self.collection.database.connection
 
-        payload = {'collection' : collection.name}
-        payload.update(queryArgs)
+        payload = {'collection': collection.name}
+        payload.update(query_args)
         payload = json.dumps(payload, cls=json_encoder, default=str)
-        URL = "%s/simple/%s" % (collection.database.URL, queryType)
-        request = self.connection.session.put(URL, data = payload)
+        URL = "%s/simple/%s" % (collection.database.URL, query_type)
+        request = self.connection.session.put(URL, data=payload)
 
-        Query.__init__(self, request, collection.database, rawResults)
+        Query.__init__(self, request, collection.database, raw_results)
 
-    def _raiseInitFailed(self, request) :
+    def _raise_init_failed(self, request):
         data = request.json()
         raise SimpleQueryError(data["errorMessage"], data)
 
-    def _developDoc(self, i) :
-        docJson = self.result[i]
-        if self.collection.type == CONST.COLLECTION_EDGE_TYPE :
-            self.result[i] = Edge(self.collection, docJson)
-        else :
-            self.result[i] = Document(self.collection, docJson)
+    def _develop_doc(self, i):
+        doc_json = self.result[i]
+        if self.collection.type == CONST.COLLECTION_EDGE_TYPE:
+            self.result[i] = Edge(self.collection, doc_json)
+        else:
+            self.result[i] = Document(self.collection, doc_json)

--- a/pyArango/theExceptions.py
+++ b/pyArango/theExceptions.py
@@ -1,144 +1,192 @@
-class pyArangoException(Exception) :
-    """The calss from witch all Exceptions inherit"""
-    def __init__(self, message, errors = None) :
+class pyArangoException(Exception):
+    """
+    The calss from witch all Exceptions inherit
+    """
+    def __init__(self, message, errors = None):
         Exception.__init__(self, message)
-        if errors is None :
+        if errors is None:
             errors = {}
         self.message = message
         self.errors = errors
 
-    def __str__(self) :
+    def __str__(self):
         return self.message + ". Errors: " + str(self.errors)
 
-class ConnectionError(pyArangoException) :
-    """Something went wrong with the connection"""
-    def __init__(self, message, URL, statusCode = "", errors = None) :
-        if errors is None :
+
+class ConnectionError(pyArangoException):
+    """
+    Something went wrong with the connection
+    """
+    def __init__(self, message, URL, statusCode = "", errors = None):
+        if errors is None:
             errors = {}
         mes = "%s. URL: %s, status: %s" % (message, URL, statusCode)
         pyArangoException.__init__(self, mes, errors)
 
-class CreationError(pyArangoException) :
-    """Something went wrong when creating something"""
-    def __init__(self, message, errors = None) :
-        if errors is None :
+
+class CreationError(pyArangoException):
+    """
+    Something went wrong when creating something
+    """
+    def __init__(self, message, errors = None):
+        if errors is None:
             errors = {}
         pyArangoException.__init__(self, message, errors)
 
-class UpdateError(pyArangoException) :
-    """Something went wrong when updating something"""
-    def __init__(self, message, errors = None) :
-        if errors is None :
+
+class UpdateError(pyArangoException):
+    """
+    Something went wrong when updating something
+    """
+    def __init__(self, message, errors = None):
+        if errors is None:
             errors = {}
         pyArangoException.__init__(self, message, errors)
 
-class DeletionError(pyArangoException) :
-    """Something went wrong when deleting something"""
-    def __init__(self, message, errors = None) :
-        if errors is None :
+
+class DeletionError(pyArangoException):
+    """
+    Something went wrong when deleting something
+    """
+    def __init__(self, message, errors = None):
+        if errors is None:
             errors = {}
         pyArangoException.__init__(self, message, errors)
 
-class TraversalError(pyArangoException) :
-    """Something went wrong when doing a graph traversal"""
-    def __init__(self, message, errors = None) :
-        if errors is None :
+
+class TraversalError(pyArangoException):
+    """
+    Something went wrong when doing a graph traversal
+    """
+    def __init__(self, message, errors = None):
+        if errors is None:
             errors = {}
         pyArangoException.__init__(self, message, errors)
 
-class ValidationError(pyArangoException) :
-    """Something went wrong when validating something"""
-    def __init__(self, message, errors = None) :
-        if errors is None :
+
+class ValidationError(pyArangoException):
+    """
+    Something went wrong when validating something
+    """
+    def __init__(self, message, errors = None):
+        if errors is None:
             errors = {}
         pyArangoException.__init__(self, message, errors)
 
-class SchemaViolation(pyArangoException) :
-    """Raised when someone tries to add a new field to an object belonging a to a Collection with enforced schema"""
-    def __init__(self, collection, field, errors = None) :
+
+class SchemaViolation(pyArangoException):
+    """
+    Raised when someone tries to add a new field to an object belonging a to a Collection with enforced schema
+    """
+    def __init__(self, collection, field, errors = None):
         if errors is None:
             errors = {}
         message = "Collection '%s' does not have a field '%s' in it's schema" % (collection.__name__, field)
         pyArangoException.__init__(self, message, errors)
 
-class InvalidDocument(pyArangoException) :
-    """Raised when a Document does not respect schema/validation defined in its collection"""
-    def __init__(self, errors) :
+
+class InvalidDocument(pyArangoException):
+    """
+    Raised when a Document does not respect schema/validation defined in its collection
+    """
+    def __init__(self, errors):
         message = "Unsuccesful validation"
         self.strErrors = []
-        for k, v in errors.items() :
+        for k, v in errors.items():
             self.strErrors.append("%s -> %s" % (k, v))
         self.strErrors = '\n\t'.join(self.strErrors)
 
         pyArangoException.__init__(self, message, errors)
 
-    def __str__(self) :
+    def __str__(self):
         strErrors = []
-        for k, v in self.errors.items() :
+        for k, v in self.errors.items():
             strErrors.append("%s -> %s" % (k, v))
         strErrors = '\n\t'.join(strErrors)
         return self.message + ":\n\t" + strErrors
 
-class SimpleQueryError(pyArangoException) :
-    """Something went wrong with a simple query"""
-    def __init__(self, message, errors = None) :
-        if errors is None :
+
+class SimpleQueryError(pyArangoException):
+    """
+    Something went wrong with a simple query
+    """
+    def __init__(self, message, errors = None):
+        if errors is None:
             errors = {}
         pyArangoException.__init__(self, message, errors)
 
-class QueryError(pyArangoException) :
-    """Something went wrong with an aql query"""
-    def __init__(self, message, errors = None) :
-        if errors is None :
+
+class QueryError(pyArangoException):
+    """
+    Something went wrong with an aql query
+    """
+    def __init__(self, message, errors = None):
+        if errors is None:
             errors = {}
         pyArangoException.__init__(self, message, errors)
 
-class AQLQueryError(pyArangoException) :
-    """Something went wrong with an aql query"""
-    def __init__(self, message, query, errors = None) :
-        if errors is None :
+
+class AQLQueryError(pyArangoException):
+    """
+    Something went wrong with an aql query
+    """
+    def __init__(self, message, query, errors = None):
+        if errors is None:
             errors = {}
         lq = []
-        for i, ll in enumerate(query.split("\n")) :
+        for i, ll in enumerate(query.split("\n")):
             lq.append("%s: %s" % (i+1, ll))
         lq = '\n'.join(lq)
 
         message = "Error in:\n%s.\n->%s" % (lq, message)
         pyArangoException.__init__(self, message, errors)
 
-class CursorError(pyArangoException) :
-    """Something went wrong when trying to fetch data with a cursor"""
-    def __init__(self, message, cursorId, errors = None) :
-        if errors is None :
+
+class CursorError(pyArangoException):
+    """
+    Something went wrong when trying to fetch data with a cursor
+    """
+    def __init__(self, message, cursorId, errors = None):
+        if errors is None:
             errors = {}
         message = "Unable to retreive data for cursor %s: %s" % (cursorId, message)
         pyArangoException.__init__(self, message, errors)
 
-class TransactionError(pyArangoException) :
-    """Something went wrong with a transaction"""
-    def __init__(self, message, action, errors = None) :
-        if errors is None :
+
+class TransactionError(pyArangoException):
+    """
+    Something went wrong with a transaction
+    """
+    def __init__(self, message, action, errors = None):
+        if errors is None:
             errors = {}
         message = "Error in: %s.\n->%s" % (action, message)
         pyArangoException.__init__(self, message, errors)
 
-class AbstractInstanciationError(Exception) :
-    """Raised when someone tries to instanciate an abstract class"""
-    def __init__(self, cls) :
+
+class AbstractInstanciationError(Exception):
+    """
+    Raised when someone tries to instanciate an abstract class
+    """
+    def __init__(self, cls):
         self.cls = cls
         self.message = "%s is abstract and is not supposed to be instanciated. Collections my inherit from it" % self.cls.__name__
         Exception.__init__(self, self.message)
 
-    def __str__(self) :
+    def __str__(self):
         return self.message
 
-class ExportError(pyArangoException) :
-    """ Something went wrong using the export cursor """
+
+class ExportError(pyArangoException):
+    """
+    Something went wrong using the export cursor 
+    """
     def __init__(self, message, errors = {} ):
         pyArangoException.__init__(self, message, errors)
 
-class DocumentNotFoundError(pyArangoException) :
-    def __init__(self, message, errors = None) :
-        if errors is None :
+
+class DocumentNotFoundError(pyArangoException):
+    def __init__(self, message, errors = None):
+        if errors is None:
             errors = {}
         pyArangoException.__init__(self, message, errors)

--- a/pyArango/validation.py
+++ b/pyArango/validation.py
@@ -1,103 +1,134 @@
 from .theExceptions import ValidationError
 
-class Validator(object) :
-    """All validators must inherit from this class"""
-    def __init__(self, *args, **kwrags) :
+class Validator(object):
+    """
+    All validators must inherit from this class
+    """
+    def __init__(self, *args, **kwrags):
         pass
 
-    def validate(self, value) :
-        """The only function that a validator must implement. Must return True if erevything went well or a ValidationError otherwise"""
+    def validate(self, value):
+        """
+        The only function that a validator must implement.
+        Must return True if erevything went well or a ValidationError otherwise
+        """
         raise NotImplemented("Should be implemented in child")
 
-    def __str__(self) :
-        """This function should be redifined in child to give a quick overview of the validator"""
+    def __str__(self):
+        """
+        This function should be redifined in child to give a quick overview of the validator
+        """
         return self.__class__.__name__
 
-class NotNull(Validator) :
-    """Checks that the Field has a non null value"""
-    def validate(self, value, zero=True, emptyString=True) :
-        if value is None or (value == 0 is zero) or (value == "" and emptyString) :
+
+class NotNull(Validator):
+    """
+    Checks that the Field has a non null value
+    """
+    def validate(self, value, zero=True, empty_string=True):
+        if value is None or (value == 0 is zero) or (value == "" and empty_string):
             raise ValidationError("Field can't have a null value: '%s'" % value)
         return True
 
-class Email(Validator) :
-    """Checks if the field contains an emailaddress"""
-    def validate(self, value) :
+
+class Email(Validator):
+    """
+    Checks if the field contains an emailaddress
+    """
+    def validate(self, value):
         import re
-        pat = '^[A-z0-9._-]+@[A-z0-9.-]+\.[A-z]{2,4}$'
-        if re.match(pat, value) is None :
+        pattern = '^[A-z0-9._-]+@[A-z0-9.-]+\.[A-z]{2,4}$'
+        if re.match(pattern, value) is None:
             raise ValidationError("The email address: %s is invalid" % value)
         return True
 
-class Numeric(Validator) :
-    """checks if the value is numerical"""
-    def validate(self, value) :
-        try :
+class Numeric(Validator):
+    """
+    checks if the value is numerical
+    """
+    def validate(self, value):
+        try:
             float(value)
-        except :
+        except:
             raise ValidationError("%s is not valid numerical value" % value)
         return True
 
-class Int(Validator) :
-    """The value must be an integer"""
-    def validate(self, value) :
-        if not isinstance(value, int) :
+
+class Int(Validator):
+    """
+    The value must be an integer
+    """
+    def validate(self, value):
+        if not isinstance(value, int):
             raise ValidationError("%s is not a valid integer" % value)
         return True
 
-class Bool(Validator) :
-    """The value must be a boolean"""
-    def validate(self, value) :
-        if not isinstance(value, bool) :
+
+class Bool(Validator):
+    """
+    The value must be a boolean
+    """
+    def validate(self, value):
+        if not isinstance(value, bool):
             raise ValidationError("%s is not a valid boolean" % value)
         return True
 
-class String(Validator) :
-    """The value must be a string or unicode"""
-    def validate(self, value) :
-        if not isinstance(value, str) and not isinstance(value, unicode) :
+
+class String(Validator):
+    """
+    The value must be a string or unicode
+    """
+    def validate(self, value):
+        if not isinstance(value, str) and not isinstance(value, unicode):
             raise ValidationError("%s is not a valid string" % value)
         return True
 
-class Enumeration(Validator) :
-    """The value must be in the allowed ones"""
-    def __init__(self, allowed) :
+
+class Enumeration(Validator):
+    """
+    The value must be in the allowed ones
+    """
+    def __init__(self, allowed):
         self.allowed = set(allowed)
   
-    def validate(self, value) :
-        if value not in self.allowed :
+    def validate(self, value):
+        if value not in self.allowed:
             raise ValidationError("%s is not among the allowed values %s" % (value, self.allowed))
         return True
 
-class Range(Validator) :
-    """The value must une [lower, upper] range"""
-    def __init__(self, lower, upper) :
+class Range(Validator):
+    """
+    The value must une [lower, upper] range
+    """
+    def __init__(self, lower, upper):
         self.lower = lower
         self.upper = upper
 
-    def validate(self, value) :
-        if value < self.lower or value > self.upper :
+    def validate(self, value):
+        if value < self.lower or value > self.upper:
             raise ValidationError("%s is not in [%s, %s]" % (value, self.lower, self.upper))
     
-    def __str__(self) :
+    def __str__(self):
         return "%s[%s, %s]" % (self.__class__.__name__, self.minLen, self.maxLen)
 
 
-class Length(Validator) :
-    """validates that the value length is between given bounds"""
-    def __init__(self, minLen, maxLen) :
-        self.minLen = minLen
-        self.maxLen = maxLen
+class Length(Validator):
+    """
+    Validates that the value length is between given bounds
+    """
+    def __init__(self, min_length, max_length):
+        self.minlength = min_length
+        self.maxlength = max_length
 
-    def validate(self, value) :
-        try :
+    def validate(self, value):
+        try:
             length = len(value)
-        except :
+        except:
             raise ValidationError("Field '%s' of type '%s' has no length" % (value, type(value)))
             
-        if self.minLen <= len(value) and len(value) <= self.maxLen :
+        if self.min_length <= len(value) and len(value) <= self.max_length:
             return True
-        raise ValidationError("Field must have a length in ['%s';'%s'] got: '%s'" % (self.minLen, self.maxLen, len(value)))
+        raise ValidationError("Field must have a length in ['%s';'%s'] got: '%s'" % (self.min_length, self.max_length, len(value)))
     
-    def __str__(self) :
-        return "%s[%s, %s]" % (self.__class__.__name__, self.minLen, self.maxLen)
+    def __str__(self):
+        return "%s[%s, %s]" % (self.__class__.__name__, self.min_length, self.max_length)


### PR DESCRIPTION
Rationale:
The main reason for building a Python driver for an third-party API is,
or should be, to allow Pythonic access to the service that is clear and
understandable to a typical Python developer, and to simplify the process from having to use requests with custom JSON.

PEP 8 should be applied unless:
- There are project specific guidelines which take precedence. This is an
  open-source project and hence should not be creating its own
guidelines that are vastly different from the recommended guidlines.
- For backwards compatability. This is a new project, so there is no
  such requirement.
- Applying PEP 8 renders the code unreadable. This does not apply here,
  as the reason that I wrote this commit is precisely because I could
not read the code without PEP 8.
- The code predates the guidline. This does not apply.
- Compatability with older versions of Python. I have left some code
  intact for this reason (for example, explicitly extending the Object
class, which is redundant in Python3, has been left for Python 2
compatability). However, this library is likely to primarily be used by
Python3 developers, and a future pull-request will introduce Python3
style improvements and optimisations.

Many of the fixes in this commit also resolve *internal* inconsistencies
(for example, highly inconsistent doc-string usage, and differing names
for variables serving the equivalent function in different locations), which is a problem
regardless of the coding style adopted.

Key Changes:
- Splitting longer lines over multiple lines (PEP recomments 79
  character line length).
- Blank lines: From PEP, two lines between top-level definitions, one
  between methods. This had not been followed.
- Imports: some module-level imports were not at the top of files as
  required by PEP. They have been moved.
- Docstrings: Changed to triple quotes everywhere (PEP 257)
            : Placed the """ on separate lines. PEP 8 regards leaving
the trailing """ on a separate line as "most important". This had not been
followed.
- Whitespaces: Amazingly, almost every one of the "Pet Peeves" for
  whitespaces listed in PEP 8 were used. Theses are particularly
annoying and unnecessary. They have been removed.
- Naming conventions: I have not changed too many names because I am not
  yet familiar enough with the code to always have good names. However,
all variable and function names were CamelCase, which is incorrect. They
have been corrected.
                    : Single-letter variable names have been replaced
whereever possible.
                    : In particlar, the letter 'o' was used as a
variable name, which is highly inadvisable due to confusion with 0. O is
explicitly prohibited by PEP, but the same reasoning applies to o.
                    : I have replaced many abbreviations. Especially
cases where multiple DIFFERENT abbreviations were used for the same
variable name, leading to confusion.

Changes Still Required:
- Names that clash with reserved words have been incorrectly adapted
  (PEP 8 - Function and Method Arguments)
- Classes inhereting from Object don't need to do so explicitly, unless
there is a Python 2 reason for doing this.
- Function annotations may be helpful in certain cases.
- The actual content of the comments is currently entirely unhelpful and
docstrings in particular need to all be rewritten.