### PR TITLE
pre-install gevent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ services:
 
 python:
   - "2.7"
-  - "3.6"
+  - "3.7"
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ services:
 
 python:
   - "2.7"
-  - "3.5"
+  - "3.6"
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,9 @@ addons:
     update: true
     
 before_script:
-  - sudo apt-get install -y python3-gevent python-gevent
   - chmod 777 ./pyArango/tests/setup_arangodb.sh
   - ./pyArango/tests/setup_arangodb.sh
-  - apt-g
-  - pip install coverage
+  - pip install coverage gevent
 
 install: python setup.py install
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,12 @@ addons:
     update: true
     
 before_script:
-  - pip install coverage gevent enum setuptools
   - chmod 777 ./pyArango/tests/setup_arangodb.sh
   - ./pyArango/tests/setup_arangodb.sh
 
 install:
   - pip install --upgrade pip
+  - pip install coverage gevent enum setuptools
   - python setup.py install
 
 script: coverage run -m unittest discover pyArango/tests/

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,13 @@ addons:
     update: true
     
 before_script:
-  - pip upgrade
   - pip install coverage gevent enum setuptools
   - chmod 777 ./pyArango/tests/setup_arangodb.sh
   - ./pyArango/tests/setup_arangodb.sh
 
-install: python setup.py install
+install:
+  - pip install --upgrade --user pip
+  - python setup.py install
 
 script: coverage run -m unittest discover pyArango/tests/
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_script:
 
 install:
   - pip install --upgrade pip
-  - pip install coverage gevent enum setuptools
+  - pip install coverage gevent setuptools
   - python setup.py install
 
 script: coverage run -m unittest discover pyArango/tests/

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,15 @@ python:
   - "2.7"
   - "3.5"
 
+addons:
+  apt:
+    update: true
+    
 before_script:
+  - sudo apt-get install -y python3-gevent python-gevent
   - chmod 777 ./pyArango/tests/setup_arangodb.sh
   - ./pyArango/tests/setup_arangodb.sh
+  - apt-g
   - pip install coverage
 
 install: python setup.py install

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,10 @@ addons:
     update: true
     
 before_script:
+  - pip upgrade
+  - pip install coverage gevent enum setuptools
   - chmod 777 ./pyArango/tests/setup_arangodb.sh
   - ./pyArango/tests/setup_arangodb.sh
-  - pip install coverage gevent enum
 
 install: python setup.py install
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ addons:
 before_script:
   - chmod 777 ./pyArango/tests/setup_arangodb.sh
   - ./pyArango/tests/setup_arangodb.sh
-  - pip install coverage gevent
+  - pip install coverage gevent enum
 
 install: python setup.py install
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ services:
 
 python:
   - "2.7"
-  - "3.7"
+  - "3.6"
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_script:
   - ./pyArango/tests/setup_arangodb.sh
 
 install:
-  - pip install --upgrade --user pip
+  - pip install --upgrade pip
   - python setup.py install
 
 script: coverage run -m unittest discover pyArango/tests/

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_script:
 
 install:
   - pip install --upgrade pip
-  - pip install coverage gevent setuptools
+  - pip install coverage gevent setuptools enum34
   - python setup.py install
 
 script: coverage run -m unittest discover pyArango/tests/

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,4 @@
+
+[bdist_wheel]
+universal = 1
+


### PR DESCRIPTION
don't make `python setup.py` install gevent, rather use apt for this since this is less error prone.