### PR TITLE
Fix url variable case for bulkImport methods.

### DIFF
--- a/pyArango/collection.py
+++ b/pyArango/collection.py
@@ -687,9 +687,9 @@ class Collection(with_metaclass(Collection_metaclass, object)) :
         params["type"] = "documents"
         params["onDuplicate"] = onDuplicate
         params["collection"] = self.name
-        URL = "%s/import" % self.database.getURL()
+        url = "%s/import" % self.database.getURL()
 
-        r = self.connection.session.post(URL, params = params, data = payload)
+        r = self.connection.session.post(url, params = params, data = payload)
         data = r.json()
         if (r.status_code == 201) and "error" not in data :
             return True
@@ -708,7 +708,7 @@ class Collection(with_metaclass(Collection_metaclass, object)) :
         params["type"] = formatType
         with open(filename) as f:
             data = f.read()
-            r = self.connection.session.post(URL, params = params, data = data)
+            r = self.connection.session.post(url, params = params, data = data)
 
             try :
                 errorMessage = "At least: %d errors. The first one is: '%s'\n\n more in <this_exception>.data" % (len(data), data[0]["errorMessage"])
@@ -723,7 +723,7 @@ class Collection(with_metaclass(Collection_metaclass, object)) :
         params["collection"] = self.name
         with open(filename) as f:
             data = f.read()
-            r = self.connection.session.post(URL, params = params, data = data)
+            r = self.connection.session.post(url, params = params, data = data)
 
             try :
                 errorMessage = "At least: %d errors. The first one is: '%s'\n\n more in <this_exception>.data" % (len(data), data[0]["errorMessage"])

--- a/pyArango/doc/source/conf.py
+++ b/pyArango/doc/source/conf.py
@@ -20,7 +20,7 @@ import sphinx_rtd_theme
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-#sys.path.insert(0, os.path.abspath('.'))
+sys.path.insert(0, os.path.abspath('.'))
 
 # -- General configuration ------------------------------------------------
 


### PR DESCRIPTION
While trying to bulk import a local JSON file, I got an error and found this simple-to-fix bug.  I chose lower case `url` as the standard variable name based on other usage in the module.

This is my first contribution to `pyArango`, let me know if anything else needs to be done to get this merged in.

Thanks!