### PR TITLE
Feature/add new 3.5 apis

### DIFF
--- a/pyArango/admin.py
+++ b/pyArango/admin.py
@@ -5,6 +5,8 @@ import types
 import requests
 
 from .connection import Connection
+from .theExceptions import (ArangoError)
+
 
 class Admin(object) :
     """administrative tasks with arangodb"""
@@ -18,7 +20,7 @@ class Admin(object) :
         if result.status_code < 400 :
             return result.json()
 
-        raise Exception("aoeu")
+        raise ArangoError(result.json()['errorMessage'], result.json())
 
     def is_cluster(self):
         status = self.status()

--- a/pyArango/admin.py
+++ b/pyArango/admin.py
@@ -1,0 +1,25 @@
+import json
+import logging
+import types
+
+import requests
+
+from .connection import Connection
+
+class Admin(object) :
+    """administrative tasks with arangodb"""
+    def __init__(self, connection):
+        self.connection = connection
+
+    def status(self):
+        """ fetches the server status."""
+        url = "%s/_admin/status" % self.connection.getEndpointURL()
+        result = self.connection.session.get(url)
+        if result.status_code < 400 :
+            return result.json()
+
+        raise Exception("aoeu")
+
+    def is_cluster(self):
+        status = self.status()
+        return status['serverInfo']['role'] == 'COORDINATOR'

--- a/pyArango/collection.py
+++ b/pyArango/collection.py
@@ -6,7 +6,7 @@ from . import consts as CONST
 
 from .document import Document, Edge
 
-from .theExceptions import ValidationError, SchemaViolation, CreationError, UpdateError, DeletionError, InvalidDocument, ExportError, DocumentNotFoundError, ArangoError, BulkOperationError
+from .theExceptions import ValidationError, SchemaViolation, CreationError, UpdateError, DeletionError, InvalidDocument, ExportError, DocumentNotFoundError, ArangoError, BulkOperationError, IndexError
 
 from .query import SimpleQuery
 from .index import Index

--- a/pyArango/collection.py
+++ b/pyArango/collection.py
@@ -266,6 +266,7 @@ class Collection(with_metaclass(Collection_metaclass, object)) :
             "geo" : {},
             "fulltext" : {},
         }
+        self.indexes_by_name = {}
 
         self.defaultDocument = getDefaultDoc(self._fields, {})
         self._isBulkInProgress = False
@@ -281,13 +282,22 @@ class Collection(with_metaclass(Collection_metaclass, object)) :
 
     def getIndexes(self) :
         """Fills self.indexes with all the indexes associates with the collection and returns it"""
+        self.indexes_by_name = {}
         url = "%s/index" % self.database.getURL()
         r = self.connection.session.get(url, params = {"collection": self.name})
         data = r.json()
         for ind in data["indexes"] :
-            self.indexes[ind["type"]][ind["id"]] = Index(collection = self, infos = ind)
+            index = Index(collection = self, infos = ind)
+            self.indexes[ind["type"]][ind["id"]] = index
+            if "name" in ind:
+                self.indexes_by_name[ind["name"]] = index
 
         return self.indexes
+
+    def getIndex(self, name):
+        if len(self.indexes_by_name) == 0:
+            raise IndexError("named indices unsupported")
+        return self.indexes_by_name[name]
 
     def activateCache(self, cacheSize) :
         """Activate the caching system. Cached documents are only available through the __getitem__ interface"""
@@ -504,7 +514,7 @@ class Collection(with_metaclass(Collection_metaclass, object)) :
         docs = data['result']
         return docs
 
-    def ensureHashIndex(self, fields, unique = False, sparse = True, deduplicate = False) :
+    def ensureHashIndex(self, fields, unique = False, sparse = True, deduplicate = False, name = None) :
         """Creates a hash index if it does not already exist, and returns it"""
         data = {
             "type" : "hash",
@@ -513,11 +523,15 @@ class Collection(with_metaclass(Collection_metaclass, object)) :
             "sparse" : sparse,
             "deduplicate": deduplicate
         }
+        if name:
+            data["name"] = name
         ind = Index(self, creationData = data)
         self.indexes["hash"][ind.infos["id"]] = ind
+        if name:
+            self.indexes_by_name[name] = ind
         return ind
 
-    def ensureSkiplistIndex(self, fields, unique = False, sparse = True, deduplicate = False) :
+    def ensureSkiplistIndex(self, fields, unique = False, sparse = True, deduplicate = False, name = None) :
         """Creates a skiplist index if it does not already exist, and returns it"""
         data = {
             "type" : "skiplist",
@@ -526,10 +540,14 @@ class Collection(with_metaclass(Collection_metaclass, object)) :
             "sparse" : sparse,
             "deduplicate": deduplicate
         }
+        if name:
+            data["name"] = name
         ind = Index(self, creationData = data)
         self.indexes["skiplist"][ind.infos["id"]] = ind
+        if name:
+            self.indexes_by_name[name] = ind
         return ind
-    def ensurePersistentIndex(self, fields, unique = False, sparse = True) :
+    def ensurePersistentIndex(self, fields, unique = False, sparse = True, name = None) :
         """Creates a persistent index if it does not already exist, and returns it"""
         data = {
             "type" : "persistent",
@@ -537,11 +555,15 @@ class Collection(with_metaclass(Collection_metaclass, object)) :
             "unique" : unique,
             "sparse" : sparse,
         }
+        if name:
+            data["name"] = name
         ind = Index(self, creationData = data)
         self.indexes["skiplist"][ind.infos["id"]] = ind
+        if name:
+            self.indexes_by_name[name] = ind
         return ind
 
-    def ensureTTLIndex(self, fields, expireAfter, unique = False, sparse = True) :
+    def ensureTTLIndex(self, fields, expireAfter, unique = False, sparse = True, name = None) :
         """Creates a TTL index if it does not already exist, and returns it"""
         data = {
             "type" : "ttl",
@@ -550,31 +572,43 @@ class Collection(with_metaclass(Collection_metaclass, object)) :
             "sparse" : sparse,
             "expireAfter" : expireAfter
         }
+        if name:
+            data["name"] = name
         ind = Index(self, creationData = data)
         self.indexes["skiplist"][ind.infos["id"]] = ind
+        if name:
+            self.indexes_by_name[name] = ind
         return ind
 
-    def ensureGeoIndex(self, fields) :
+    def ensureGeoIndex(self, fields, name = None) :
         """Creates a geo index if it does not already exist, and returns it"""
         data = {
             "type" : "geo",
             "fields" : fields,
         }
+        if name:
+            data["name"] = name
         ind = Index(self, creationData = data)
         self.indexes["geo"][ind.infos["id"]] = ind
+        if name:
+            self.indexes_by_name[name] = ind
         return ind
 
-    def ensureFulltextIndex(self, fields, minLength = None) :
+    def ensureFulltextIndex(self, fields, minLength = None, name = None) :
         """Creates a fulltext index if it does not already exist, and returns it"""
         data = {
             "type" : "fulltext",
             "fields" : fields,
         }
+        if name:
+            data["name"] = name
         if minLength is not None :
             data["minLength"] = minLength
 
         ind = Index(self, creationData = data)
         self.indexes["fulltext"][ind.infos["id"]] = ind
+        if name:
+            self.indexes_by_name[name] = ind
         return ind
 
 

--- a/pyArango/document.py
+++ b/pyArango/document.py
@@ -373,6 +373,14 @@ class Document(object) :
         except AttributeError :
             raise AttributeError("%s does not seem to be a valid Edges object" % edges)
 
+    def getResponsibleShard(self):
+        """ If we're working with an arangodb cluster, we can use this method to fetch where a document lives."""
+
+        result = self.connection.session.put("%s/responsibleShard" % self.collection.getURL(), data = json.dumps(self.getStore()))
+        if result.status_code == 200:
+            return result.json()["shardId"]
+        raise ArangoError(result.json()['errorMessage'], result.json())
+
     def getStore(self) :
         """return the store in a dict format"""
         store = self._store.getStore()

--- a/pyArango/document.py
+++ b/pyArango/document.py
@@ -1,5 +1,5 @@
 import json, types
-from .theExceptions import (CreationError, DeletionError, UpdateError, ValidationError, SchemaViolation, InvalidDocument)
+from .theExceptions import (CreationError, DeletionError, UpdateError, ValidationError, SchemaViolation, InvalidDocument, ArangoError)
 
 __all__ = ["DocumentStore", "Document", "Edge"]
 

--- a/pyArango/tests/setup_arangodb.sh
+++ b/pyArango/tests/setup_arangodb.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-docker pull arangodb/arangodb-preview:devel
-docker run -d -e ARANGO_ROOT_PASSWORD="root" -p 8529:8529 arangodb/arangodb-preview:devel
+docker pull arangodb/arangodb-preview:devel-nightly
+docker run -d -e ARANGO_ROOT_PASSWORD="root" -p 8529:8529 arangodb/arangodb-preview:devel-nightly
 
 sleep 2
 

--- a/pyArango/theExceptions.py
+++ b/pyArango/theExceptions.py
@@ -31,6 +31,13 @@ class CreationError(pyArangoException) :
             errors = {}
         pyArangoException.__init__(self, message, errors)
 
+class IndexError(pyArangoException) :
+    """wasn't able to get the index"""
+    def __init__(self, message, errors = None) :
+        if errors is None :
+            errors = {}
+        pyArangoException.__init__(self, message, errors)
+
 class UpdateError(pyArangoException) :
     """Something went wrong when updating something"""
     def __init__(self, message, errors = None) :


### PR DESCRIPTION
- add first wrapper for `admin` series calls to detect whether we're talking to a cluster or a single server
- add getResponsibleShard() to documents
- add named indices

- tests may now execute different tests depending on version and cluster of the SUT.