### PR TITLE
Connection, database actions and foxx can only be called when mount exists. Added tasks in Database

### DIFF
--- a/pyArango/action.py
+++ b/pyArango/action.py
@@ -1,0 +1,75 @@
+"""Action Base Classes to do actions on to db."""
+
+class ConnectionAction:
+    """Base class for using the session to execute action."""
+
+    def __init__(self, connection):
+        """Initialise connection."""
+        self.connection = connection
+
+    @property
+    def session(self):
+        """Session of the connection."""
+        return self.connection.session
+
+    @property
+    def end_point_url(self):
+        """End point url for connection."""
+        return self.connection.getEndpointURL()
+
+    def get(self, url, **kwargs):
+        """HTTP GET Method."""
+        action_url = '%s%s' % (self.end_point_url, url)
+        return self.session.get(action_url, **kwargs)
+
+    def post(self, url, data=None, json=None, **kwargs):
+        """HTTP POST Method."""
+        action_url = '%s%s' % (self.end_point_url, url)
+        return self.session.post(
+            action_url, data, json, **kwargs
+        )
+
+    def put(self, url, data=None, **kwargs):
+        """HTTP PUT Method."""
+        action_url = '%s%s' % (self.end_point_url, url)
+        return self.session.put(action_url, data, **kwargs)
+
+    def head(self, url, **kwargs):
+        """HTTP HEAD Method."""
+        action_url = '%s%s' % (self.end_point_url, url)
+        return self.session.head(action_url, **kwargs)
+
+    def options(self, url, **kwargs):
+        """HTTP OPTIONS Method."""
+        action_url = '%s%s' % (self.end_point_url, url)
+        return self.session.options(action_url, **kwargs)
+
+    def patch(self, url, data=None, **kwargs):
+        """HTTP PATCH Method."""
+        action_url = '%s%s' % (self.end_point_url, url)
+        return self.session.patch(action_url, data, **kwargs)
+
+    def delete(self, url, **kwargs):
+        """HTTP DELETE Method."""
+        action_url = '%s%s' % (self.end_point_url, url)
+        return self.session.delete(action_url, **kwargs)
+
+
+class DatabaseAction(ConnectionAction):
+    """Base class for using the session to execute action."""
+
+    def __init__(self, database):
+        """Initialise database."""
+        self.database = database
+
+    @property
+    def session(self):
+        """Session of the connection."""
+        return self.database.connection.session
+
+    @property
+    def end_point_url(self):
+        """End point url for database."""
+        return '%s/_db/%s' % (
+            self.database.connection.getEndpointURL(), self.database.name
+        )

--- a/pyArango/connection.py
+++ b/pyArango/connection.py
@@ -4,6 +4,7 @@ from datetime import datetime
 
 import requests
 
+from .action import ConnectionAction
 from .database import Database, DBHandle
 from .theExceptions import CreationError, ConnectionError
 from .users import Users
@@ -124,6 +125,7 @@ class Connection(object):
         self.use_jwt_authentication = use_jwt_authentication
         self.use_lock_for_reseting_jwt = use_lock_for_reseting_jwt
         self.max_retries = max_retries
+        self.action = ConnectionAction(self)
 
         self.databases = {}
         self.verbose = verbose

--- a/pyArango/database.py
+++ b/pyArango/database.py
@@ -9,6 +9,7 @@ from . import graph as GR
 from .action import DatabaseAction
 from .document import Document
 from .foxx import Foxx
+from .tasks import Tasks
 from .graph import Graph
 from .query import AQLQuery
 from .theExceptions import CreationError, UpdateError, AQLQueryError, TransactionError, AQLFetchError
@@ -26,6 +27,7 @@ class Database(object) :
         self.collections = {}
         self.graphs = {}
         self.foxx = Foxx(self)
+        self.tasks = Tasks(self)
 
         self.reload()
 

--- a/pyArango/database.py
+++ b/pyArango/database.py
@@ -6,6 +6,7 @@ from . import collection as COL
 from . import consts as CONST
 from . import graph as GR
 
+from .action import DatabaseAction
 from .document import Document
 from .foxx import Foxx
 from .graph import Graph
@@ -21,10 +22,10 @@ class Database(object) :
 
         self.name = name
         self.connection = connection
-        self.foxx = Foxx(self)
+        self.action = DatabaseAction(self)
         self.collections = {}
-
         self.graphs = {}
+        self.foxx = Foxx(self)
 
         self.reload()
 
@@ -92,6 +93,7 @@ class Database(object) :
         "reloads collections and graphs"
         self.reloadCollections()
         self.reloadGraphs()
+        self.foxx.reload()
 
     def createCollection(self, className = 'Collection', **colProperties) :
         """Creates a collection and returns it.

--- a/pyArango/tasks.py
+++ b/pyArango/tasks.py
@@ -1,0 +1,58 @@
+"""All Task related methods."""
+
+
+class Tasks:
+    """Tasks for database."""
+
+    URL = '/_api/tasks'
+
+    def __init__(self, database):
+        """Initialise the database."""
+        self.database = database
+
+    def __call__(self):
+        """All the active tasks in the db."""
+        response = self.database.action.get(self.URL)
+        response.raise_for_status()
+        return response.json()
+
+    def fetch(self, task_id):
+        """Fetch the task for given task_id."""
+        url = '{tasks_url}/{task_id}'.format(
+            tasks_url=self.URL, task_id=task_id
+        )
+        response = self.database.action.get(url)
+        response.raise_for_status()
+        return response.json()
+
+    def create(
+            self, name, command, params=None,
+            period=None, offset=None, task_id=None
+    ):
+        """Create a task with given command and its parameters."""
+        task = {'name': name, 'command': command, 'params': params}
+        if period is not None:
+            task['period'] = period
+            if offset is not None:
+                task['offset'] = offset
+
+        if task_id is not None:
+            task['id'] = task_id
+            url = '{tasks_url}/{task_id}'.format(
+                tasks_url=self.URL, task_id=task_id
+            )
+        else:
+            url = self.URL
+
+        response = self.database.action.post(url, json=task)
+        response.raise_for_status()
+        return response.json()
+
+    def delete(self, task_id):
+        """Delete the task for given task_id."""
+        url = '{tasks_url}/{task_id}'.format(
+            tasks_url=self.URL, task_id=task_id
+        )
+        response = self.database.action.delete(url)
+        response.raise_for_status()
+        return response.json()

--- a/pyArango/tests/tests.py
+++ b/pyArango/tests/tests.py
@@ -860,6 +860,24 @@ class pyArangoTests(unittest.TestCase):
         response = self.db.foxx.service("/_admin/aardvark").get("/index.html")
         self.assertEqual(response.status_code, 200, "Check if db is running")
 
+    def test_tasks(self):
+        db_tasks = self.db.tasks
+        self.assertListEqual(db_tasks(), [])
+        task = db_tasks.create(
+            'sample-task', 'console.log("sample-task", new Date());',
+            period=10
+        )
+        task_id = task['id']
+        fetched_task = db_tasks.fetch(task_id)
+        fetched_task['offset'] = int(fetched_task['offset'])
+        self.assertDictEqual(task, fetched_task)
+        tasks = db_tasks()
+        tasks[0]['offset'] = int(tasks[0]['offset'])
+        self.assertListEqual(tasks, [task])
+        db_tasks.delete(task_id)
+        self.assertListEqual(db_tasks(), [])
+
+
 if __name__ == "__main__" :
     # Change default username/password in bash like this:
     # export ARANGODB_ROOT_USERNAME=myUserName

--- a/pyArango/tests/tests.py
+++ b/pyArango/tests/tests.py
@@ -852,8 +852,8 @@ class pyArangoTests(unittest.TestCase):
 
         Connection(arangoURL=ARANGODB_URL, username="pyArangoTest_tesla", password="newpass")
 
-    def test_foxx(self):
-        response = self.db.foxx.get("/_admin/aardvark/index.html")
+    def test_action(self):
+        response = self.db.action.get("/_admin/aardvark/index.html")
         self.assertEqual(response.status_code, 200, "Check if db is running")
 
     def test_foxx_service(self):


### PR DESCRIPTION
Example.
```python
>>> from pyArango import connection
>>> conn = connection.Connection(username, password)
>>> test_db = conn['test']
>>> test_db.foxx.services
[{'mount': '/_admin/aardvark',
  'name': 'aardvark',
  'version': '3.0.0',
  'provides': {},
  'development': False,
  'legacy': False},
 {'mount': '/_api/foxx',
  'name': 'foxx-manager',
  'version': '3.2.0',
  'provides': {},
  'development': False,
  'legacy': False}]
>>> test_db.foxx.mounts
{'/_admin/aardvark', '/_api/foxx'}
>>> test_db.foxx.service('/_admin/aardvark').get('/index.html')
<Response [200]>
>>> test_db.action.get('/_admin/aardvark/index.html')
<Response [200]>
>>> conn.action.get('/_db/test/_admin/aardvark/index.html')
<Response [200]>
>>> test_db.tasks.create('sample-task', 'console.log("sample-task", new Date());', period=10)
{'id': '1257206',
'name': 'sample-task',
'created': 1560173763.5678825,
'type': 'periodic',
'period': 10,
'offset': 0,
'command': '(function (params) { console.log("sample-task", new Date()); } )(params);',
'database': 'test_db_2'}
>>> test_db.tasks()
[{'id': '1257206',
  'name': 'sample-task',
  'created': 1560173763.5678825,
  'type': 'periodic',
  'period': 10,
  'offset': 1e-06,
  'command': '(function (params) { console.log("sample-task", new Date()); } )(params);',
  'database': 'test_db_2'}]
>>> test_db.tasks.fetch('1257206')
{'id': '1257206',
'name': 'sample-task',
'created': 1560173763.5678825,
'type': 'periodic',
'period': 10,
'offset': 1e-06,
'command': '(function (params) { console.log("sample-task", new Date()); } )(params);',
'database': 'test_db_2'}
>>> test_db.tasks.delete('1257206')
{'error': False, 'code': 200, 'result': '(non-representable type)'}
>>> test_db.tasks()
[]
```