### PR TITLE
Fix abnormal aqlQuery

### DIFF
--- a/pyArango/query.py
+++ b/pyArango/query.py
@@ -119,7 +119,7 @@ class Query(object):
         try:
             return self.result[i]
         except IndexError as e:
-            return []
+            self.nextBatch()
 
     def __len__(self):
         """Returns the number of elements in the query results"""


### PR DESCRIPTION
This pull is to fix the issue #160, instead of returning an empty array when there is no more item, the query should call for the next batch instead. Inside the `nextBatch()` function already handle the iteration stop when running out of result.