### PR TITLE
Added support for satellite graphs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -310,6 +310,45 @@ to that document are also deleted.
  # deleting one of them along with the edge
  theGraph.deleteVertex(h2)
 
+Creating a Graph
+-----------------
+
+from pyArango.connection import *
+from pyArango.collection import Collection, Edges, Field
+from pyArango.graph import Graph, EdgeDefinition
+
+databaseName = "satellite_graph_db"
+
+conn = Connection()
+
+# Cleanup (if needed)
+try:
+    conn.createDatabase(name=databaseName)
+except Exception:
+    pass
+
+# Select our "satellite_graph_db" database
+db = conn[databaseName] # all databases are loaded automatically into the connection and are accessible in this fashion
+
+# Define our vertex to use
+class Humans(Collection):
+    _fields = {
+        "name": Field()
+    }
+
+# Define our edge to use
+class Friend(Edges):
+    _fields = {
+        "lifetime": Field()
+    }
+
+# Here's how you define a Satellite Graph
+class MySatelliteGraph(Graph) :
+    _edgeDefinitions = [EdgeDefinition("Friend", fromCollections=["Humans"], toCollections=["Humans"])]
+    _orphanedCollections = []
+
+theSatelliteGraph = db.createSatelliteGraph("MySatelliteGraph")
+
 Document Cache
 --------------
 

--- a/README.rst
+++ b/README.rst
@@ -310,44 +310,49 @@ to that document are also deleted.
  # deleting one of them along with the edge
  theGraph.deleteVertex(h2)
 
-Creating a Graph
+Creating a Satellite Graph
 -----------------
 
-from pyArango.connection import *
-from pyArango.collection import Collection, Edges, Field
-from pyArango.graph import Graph, EdgeDefinition
+If you want to benefit from the advantages of satellite graphs, you can also create them of course.
+Please read the official ArangoDB Documentation for further technical information.
 
-databaseName = "satellite_graph_db"
+.. code:: python
 
-conn = Connection()
+  from pyArango.connection import *
+  from pyArango.collection import Collection, Edges, Field
+  from pyArango.graph import Graph, EdgeDefinition
 
-# Cleanup (if needed)
-try:
-    conn.createDatabase(name=databaseName)
-except Exception:
-    pass
+  databaseName = "satellite_graph_db"
 
-# Select our "satellite_graph_db" database
-db = conn[databaseName] # all databases are loaded automatically into the connection and are accessible in this fashion
+  conn = Connection()
 
-# Define our vertex to use
-class Humans(Collection):
-    _fields = {
-        "name": Field()
-    }
+  # Cleanup (if needed)
+  try:
+      conn.createDatabase(name=databaseName)
+  except Exception:
+      pass
 
-# Define our edge to use
-class Friend(Edges):
-    _fields = {
-        "lifetime": Field()
-    }
+  # Select our "satellite_graph_db" database
+  db = conn[databaseName] # all databases are loaded automatically into the connection and are accessible in this fashion
 
-# Here's how you define a Satellite Graph
-class MySatelliteGraph(Graph) :
-    _edgeDefinitions = [EdgeDefinition("Friend", fromCollections=["Humans"], toCollections=["Humans"])]
-    _orphanedCollections = []
+  # Define our vertex to use
+  class Humans(Collection):
+      _fields = {
+          "name": Field()
+      }
 
-theSatelliteGraph = db.createSatelliteGraph("MySatelliteGraph")
+  # Define our edge to use
+  class Friend(Edges):
+      _fields = {
+          "lifetime": Field()
+      }
+
+  # Here's how you define a Satellite Graph
+  class MySatelliteGraph(Graph) :
+      _edgeDefinitions = [EdgeDefinition("Friend", fromCollections=["Humans"], toCollections=["Humans"])]
+      _orphanedCollections = []
+
+  theSatelliteGraph = db.createSatelliteGraph("MySatelliteGraph")
 
 Document Cache
 --------------

--- a/pyArango/database.py
+++ b/pyArango/database.py
@@ -143,7 +143,7 @@ class Database(object):
         sid = _id.split("/")
         return self[sid[0]][sid[1]]
 
-    def createGraph(self, name, createCollections = True, isSmart = False, numberOfShards = None, smartGraphAttribute = None):
+    def createGraph(self, name, createCollections = True, isSmart = False, numberOfShards = None, smartGraphAttribute = None, replicationFactor = None, writeConcern = None):
         """Creates a graph and returns it. 'name' must be the name of a class inheriting from Graph.
         Checks will be performed to make sure that every collection mentionned in the edges definition exist. Raises a ValueError in case of
         a non-existing collection."""
@@ -171,6 +171,10 @@ class Database(object):
             options['numberOfShards'] = numberOfShards
         if smartGraphAttribute:
             options['smartGraphAttribute'] = smartGraphAttribute
+        if replicationFactor:
+            options['replicationFactor'] = replicationFactor
+        if writeConcern:
+            options['writeConcern'] = writeConcern
 
         payload = {
                 "name": name,
@@ -194,6 +198,9 @@ class Database(object):
         else:
             raise CreationError(data["errorMessage"], data)
         return self.graphs[name]
+
+    def createSatelliteGraph(self, name, createCollections = True, writeConcern = None):
+        return self.createGraph(name, createCollections, False, None, None, "satellite", None);
 
     def hasCollection(self, name):
         """returns true if the databse has a collection by the name of 'name'"""

--- a/pyArango/database.py
+++ b/pyArango/database.py
@@ -199,7 +199,7 @@ class Database(object):
             raise CreationError(data["errorMessage"], data)
         return self.graphs[name]
 
-    def createSatelliteGraph(self, name, createCollections = True, writeConcern = None):
+    def createSatelliteGraph(self, name, createCollections = True):
         return self.createGraph(name, createCollections, False, None, None, "satellite", None);
 
     def hasCollection(self, name):


### PR DESCRIPTION
Also added two new graph (cluster) option parameters:
- replicationFactor
- writeConcern

See: https://www.arangodb.com/docs/stable/http/gharial-management.html#create-a-graph

Simple example:
```
from pyArango.connection import *
from pyArango.collection import Collection, Edges, Field
from pyArango.graph import Graph, EdgeDefinition

databaseName = "satellite_graph_db"

conn = Connection()

# Cleanup (if needed)
try:
    conn.createDatabase(name=databaseName)
except Exception:
    pass

# Select our "satellite_graph_db" database
db = conn[databaseName] # all databases are loaded automatically into the connection and are accessible in this fashion

# Define our vertex to use
class Humans(Collection):
    _fields = {
        "name": Field()
    }

# Define our edge to use
class Friend(Edges):
    _fields = {
        "lifetime": Field()
    }

# Here's how you define a Satellite Graph
class MySatelliteGraph(Graph) :
    _edgeDefinitions = [EdgeDefinition("Friend", fromCollections=["Humans"], toCollections=["Humans"])]
    _orphanedCollections = []

theSatelliteGraph = db.createSatelliteGraph("MySatelliteGraph")
```