### PR TITLE
change "validation" attribute name to "schema"

### DIFF
--- a/examples/json_schema_validation_in_db.py
+++ b/examples/json_schema_validation_in_db.py
@@ -10,14 +10,16 @@ def main():
     db = conn["_system"]
     name = "pyArangoValidation"
 
-    validation = {
+    schema = {
         "rule" : {
             "properties" : {
                 "value" : {
                     "type" : "number"
                 }
             }
-        }
+        },
+        "level" : "strict",
+        "message" : "invalid document - schema validation failed!"
     }
 
     collection = None
@@ -27,7 +29,7 @@ def main():
 
     collection = db.createCollection(
         name = name,
-        validation = validation
+        schema = schema
     )
 
     try:


### PR DESCRIPTION
change "validation" attribute name to "schema" after the corresponding API changed during the ArangoDB 3.7 alpha phase.