### PR TITLE
add simple driver test wrapper script

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+PYTHON=python3
+while [ $# -gt 0 ];  do
+    case "$1" in
+        --instanceUrl)
+            shift
+            export ARANGODB_URL=$1
+            shift
+            ;;
+        --instanceEndpoint)
+            shift
+            shift
+            # don't care
+            ;;
+        --auth)
+            shift
+            shift
+            # don't care
+            ;;
+        --username)
+            shift
+            export ARANGODB_ROOT_USERNAME=$1
+            shift
+            ;;
+        --password)
+            shift
+            export ARANGODB_ROOT_PASSWORD=$1
+            shift
+            ;;
+        --enterprise)
+            shift
+            # don't care
+            ;;
+        --no-enterprise)
+            shift
+            # don't care
+            ;;
+        --host)
+            shift
+            shift
+            # don't care...
+            ;;
+        --port)
+            shift
+            shift
+            # don't care...
+            ;;
+        --deployment-mode)
+            shift
+            shift
+            # don't care...
+            ;;
+        --testsuite)
+            shift
+            shift
+            # TODO: howto pass testsuite filters?
+            ;;
+        --filter)
+            shift
+            shift
+            # TODO: howto pass testcase filters?
+            ;;
+        --python-exe)
+            shift
+            export PYTHON=$1
+            shift
+            ;;
+        *)
+            echo "What? my mother was a saint! $1"
+            shift
+    esac
+done
+
+$PYTHON setup.py build
+
+export PYTHONPATH=$(pwd)/build/lib
+
+exec $PYTHON pyArango/tests/tests.py 2>&1


### PR DESCRIPTION
This script will provide an easy integration for @arangodb developers to run this drivers unittests.
https://github.com/arangodb/arangodb/pull/12684 is the upstream PR that adds these functionality.

TBC: could/should we  use python virtualenv here? and if yes, how to?

Such an invocation could look like this:
```
./scripts/unittest driver --driversource ../pyArango
================================================================================
Executing test driver
================================================================================

2020-09-22T15:56:13Z [1181202] S INFO [e52b0] {general} ArangoDB 3.8.0-devel enterprise [linux-DEBUG] 64bit maintainer mode, using build heads/devel-0-gb89c9bd98f4-dirty, VPack 0.1.33, RocksDB 6.8.0, ICU 64.2, V8 7.9.317, OpenSSL 1.1.1g  21 Apr 2020
2020-09-22T15:56:13Z [1181202] S WARNING [0458b] {general} This is a maintainer version intended for debugging. DO NOT USE IN PRODUCTION!
2020-09-22T15:56:13Z [1181202] S WARNING [bd666] {general} ==============================================================================
2020-09-22T15:56:13Z [1181202] S INFO [75ddc] {general} detected operating system: Linux version 5.8.0-1-amd64 (debian-kernel@lists.debian.org) (gcc-10 (Debian 10.2.0-6) 10.2.0, GNU ld (GNU Binutils for Debian) 2.35) #1 SMP Debian 5.8.7-1 (2020-09-05)
2020-09-22T15:56:13Z [1181202] S INFO [25362] {memory} Available physical memory: 67299463168 bytes, available cores: 32
2020-09-22T15:56:13Z [1181202] S WARNING [e8b68] {memory} /sys/kernel/mm/transparent_hugepage/enabled is set to 'always'. It is recommended to set it to a value of 'never' or 'madvise'
2020-09-22T15:56:13Z [1181202] S WARNING [f3108] {memory} execute 'sudo bash -c "echo madvise > /sys/kernel/mm/transparent_hugepage/enabled"'
2020-09-22T15:56:13Z [1181202] S WARNING [f3108] {memory} execute 'sudo bash -c "echo madvise > /sys/kernel/mm/transparent_hugepage/defrag"'
2020-09-22T15:56:13Z [1181202] S INFO [144fe] {general} using storage engine 'rocksdb'
2020-09-22T15:56:13Z [1181202] S INFO [3bb7d] {cluster} Starting up with role SINGLE
2020-09-22T15:56:13Z [1181202] S INFO [6ea38] {general} using endpoint 'http+tcp://127.0.0.1:24420' for non-encrypted requests
2020-09-22T15:56:13Z [1181202] S INFO [a1c60] {syscall} file-descriptors (nofiles) hard limit is 1048576, soft limit is 1048576
2020-09-22T15:56:13Z [1181202] S INFO [e6460] {general} created base application directory '/tmp/arangosh_E0SGji/driver_test/apps/_db'
2020-09-22T15:56:14Z [1181202] S INFO [65273] {backup} Checking if old data from before a restore operation needs to be deleted in the background, scheduling...
2020-09-22T15:56:14Z [1181202] S INFO [fdedb] {backup} Checking if pre restore data needs to be deleted...
2020-09-22T15:56:14Z [1181202] S INFO [365ec] {general} You are using a milestone/alpha/beta/preview version ('3.8.0-devel') of ArangoDB
Tue Sep 22 2020 17:56:14 GMT+0200 (Central European Summer Time) reconnecting http://127.0.0.1:24420
Tue Sep 22 2020 17:56:14 GMT+0200 (Central European Summer Time) up and running in 1.0063982009887695 seconds
Tue Sep 22 2020 17:56:14 GMT+0200 (Central European Summer Time) sniffing template:
  tcpdump -ni lo -s0 -w /tmp/out.pcap port 24420

  [single] up with pid 1181202 on port 24420


2020-09-22T15:56:14.564Z [============] runInDriverTest: Trying driver_test.js ... 
2020-09-22T15:56:14Z [1181202] S INFO [cf3f4] {general} ArangoDB (version 3.8.0-devel enterprise [linux-DEBUG]) is ready for business. Have fun!
2020-09-22T15:56:15Z [1181202] S ERROR [1964a] {general} Could not create database: duplicate database name 'test_db_2'
2020-09-22T15:56:22Z [1181202] S INFO [365ec] {general} sample-task Tue Sep 22 2020 17:56:22 GMT+0200 (Central European Summer Time)
2020-09-22T15:56:23Z [1181202] S WARNING [11928] {general} caught exception in RestUsersHandler: user not found
running build
running build_py
............................................
----------------------------------------------------------------------
Ran 44 tests in 8.446s

OK


Tue Sep 22 2020 17:56:23 GMT+0200 (Central European Summer Time) Shutting down...
Tue Sep 22 2020 17:56:23 GMT+0200 (Central European Summer Time) Shutdown order [{"role":"single","port":24420,"endpoint":"tcp://127.0.0.1:24420","rootDir":"/tmp/arangosh_E0SGji/driver_test","url":"http://127.0.0.1:24420","args":{"configuration":"/home/willi/src/devel4/etc/testing/arangod-single.conf","define":"TOP_DIR=/home/willi/src/devel4","javascript.app-path":"/tmp/arangosh_E0SGji/driver_test/apps","javascript.copy-installation":false,"http.trusted-origin":"all","temp.path":"/tmp/arangosh_E0SGji/driver_test/tmp","server.storage-engine":"rocksdb","server.endpoint":"tcp://127.0.0.1:24420","database.directory":"/tmp/arangosh_E0SGji/driver_test/data","log.file":"/tmp/arangosh_E0SGji/driver_test/log"},"pid":1181202,"name":"single - 24420","stats":{"minorPageFaults":42922,"majorPageFaults":0,"userTime":5.15,"systemTime":0.53,"numberOfThreads":54,"residentSize":434372608,"residentSizePercent":0.006454325005768224,"virtualSize":3646717952,"rchar":16161413,"wchar":7578022,"syscr":7040,"syscw":6179,"read_bytes":0,"write_bytes":8052736,"cancelled_write_bytes":8192}}]
Tue Sep 22 2020 17:56:23 GMT+0200 (Central European Summer Time) http://127.0.0.1:24420/_admin/shutdown

Tue Sep 22 2020 17:56:23 GMT+0200 (Central European Summer Time) Commanded shut down: {"role":"single","port":24420,"endpoint":"tcp://127.0.0.1:24420","rootDir":"/tmp/arangosh_E0SGji/driver_test","url":"http://127.0.0.1:24420","args":{"configuration":"/home/willi/src/devel4/etc/testing/arangod-single.conf","define":"TOP_DIR=/home/willi/src/devel4","javascript.app-path":"/tmp/arangosh_E0SGji/driver_test/apps","javascript.copy-installation":false,"http.trusted-origin":"all","temp.path":"/tmp/arangosh_E0SGji/driver_test/tmp","server.storage-engine":"rocksdb","server.endpoint":"tcp://127.0.0.1:24420","database.directory":"/tmp/arangosh_E0SGji/driver_test/data","log.file":"/tmp/arangosh_E0SGji/driver_test/log"},"pid":1181202,"name":"single - 24420","stats":{"minorPageFaults":42922,"majorPageFaults":0,"userTime":5.15,"systemTime":0.53,"numberOfThreads":54,"residentSize":434372608,"residentSizePercent":0.006454325005768224,"virtualSize":3646717952,"rchar":16161413,"wchar":7578022,"syscr":7040,"syscw":6179,"read_bytes":0,"write_bytes":8052736,"cancelled_write_bytes":8192},"exitStatus":{"status":"RUNNING"}}
1 single(s) are still running...
1 single(s) are still running...
1 single(s) are still running...
2020-09-22T15:56:26Z [1181202] S INFO [4bcb9] {general} ArangoDB has been shut down
1 single(s) are still running...
Tue Sep 22 2020 17:56:27 GMT+0200 (Central European Summer Time) Server "single" shutdown: Success: pid 1181202
done.

================================================================================'
TEST RESULTS
================================================================================
* Test "driver"
    [SUCCESS] driver_test.js

 * Overall state: Success
```