### PR TITLE
Fix bad error check causing bulk import methods to fail

### DIFF
--- a/pyArango/collection.py
+++ b/pyArango/collection.py
@@ -748,10 +748,8 @@ class Collection(with_metaclass(Collection_metaclass, object)):
             data = f.read()
             r = self.connection.session.post(url, params = params, data = data)
 
-            try:
-                errorMessage = "At least: %d errors. The first one is: '%s'\n\n more in <this_exception>.data" % (len(data), data[0]["errorMessage"])
-            except KeyError:
-                raise UpdateError(data['errorMessage'], data)
+            if r.status_code != 201:
+                raise UpdateError('Unable to bulk import JSON', r)
 
     def bulkImport_values(self, filename, onDuplicate="error", **params):
         """bulk import from a file repecting arango's json format"""
@@ -763,10 +761,8 @@ class Collection(with_metaclass(Collection_metaclass, object)):
             data = f.read()
             r = self.connection.session.post(url, params = params, data = data)
 
-            try:
-                errorMessage = "At least: %d errors. The first one is: '%s'\n\n more in <this_exception>.data" % (len(data), data[0]["errorMessage"])
-            except KeyError:
-                raise UpdateError(data['errorMessage'], data)
+            if r.status_code != 201:
+                raise UpdateError('Unable to bulk import values', r)
 
     def truncate(self):
         """deletes every document in the collection"""


### PR DESCRIPTION
Fixes #188 and #203 

For some reason it seems like the bulkImport methods were expecting the data being POSTed to be altered... the requests library doesn't do that.  Since this entirely broke the error checking and thus the methods altogether, I replaced it with a simple status_code check.  201 is successful [per the docs](https://www.arangodb.com/docs/stable/http/bulk-imports.html#imports-documents-from-json), so if it isn't 201, raise an UpdateError with the response data.

(Sorry - got it right this time!)