### PR TITLE
Added connection pool_maxsize parameter

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,8 @@
+Unreleased
+=====
+
+* Added parameter ``pool_maxsize`` on class ``Connection`` to allow user configure the http pool size.
+
 2.0.1
 =====
 
@@ -10,7 +15,7 @@
 * added to_default function to reset a document to its default values
 * fixed bug in default documents where default values could be overwritten
 * default value for fields is now None
-* defaual value for fields can now be a callable
+* default value for fields can now be a callable
 
 1.3.5
 =====


### PR DESCRIPTION
### Problem
Requests discarded, losing data. 

## Context
 The library `requests` has a default pool size of 10 connections, so, when we need to use more threads than this default value the requests are discarded. 

###  Solution
Added a parameter in the `Connection` constructor to specify the max size of the HTTP pool connections.