### PR TITLE
Adding timeout to session object for hanging connections

### DIFF
--- a/pyArango/connection.py
+++ b/pyArango/connection.py
@@ -88,7 +88,7 @@ class AikidoSession:
             single_session=True,
             log_requests=False,
             pool_maxsize=10,
-            timeout=10,
+            timeout=30,
     ):
         if username:
             self.auth = (username, password)
@@ -208,7 +208,7 @@ class Connection(object):
             max_retries=5,
             max_conflict_retries=5,
             pool_maxsize=10,
-            timeout=10
+            timeout=30
     ):
 
         if loadBalancing not in Connection.LOAD_BLANCING_METHODS:

--- a/pyArango/tests/tests.py
+++ b/pyArango/tests/tests.py
@@ -1075,14 +1075,8 @@ class pyArangoTests(unittest.TestCase):
 
     def test_timeout_parameter(self):
         # Create a Connection object with the desired timeout
-        # Create a mock AikidoSession class
-        mock_aikido_session = MagicMock()
-
         timeout = 120
-        connection = Connection(arangoURL='http://127.0.0.1:8529', username='root', password='root', timeout=timeout)
-
-        # Call the reload method
-        connection.reload()
+        connection = Connection(arangoURL=ARANGODB_URL, username=ARANGODB_ROOT_USERNAME, password=ARANGODB_ROOT_PASSWORD, timeout=timeout)
 
         # Verify that the Connection session was created with the correct timeout
         assert connection.session.timeout == timeout

--- a/pyArango/tests/tests.py
+++ b/pyArango/tests/tests.py
@@ -1,5 +1,6 @@
 import unittest, copy
 import os
+from unittest.mock import MagicMock, patch
 
 from pyArango.connection import *
 from pyArango.database import *
@@ -1072,7 +1073,20 @@ class pyArangoTests(unittest.TestCase):
         db_tasks.delete(task_id)
         self.assertListEqual(db_tasks(), [])
 
+    def test_timeout_parameter(self):
+        # Create a Connection object with the desired timeout
+        # Create a mock AikidoSession class
+        mock_aikido_session = MagicMock()
 
+        timeout = 30
+        connection = Connection(arangoURL='http://127.0.0.1:8529', username='root', password='root', timeout=timeout)
+
+        # Call the reload method
+        connection.reload()
+
+        # Verify that the Connection session was created with the correct timeout
+        assert connection.session.timeout == timeout
+            
 if __name__ == "__main__":
     # Change default username/password in bash like this:
     # export ARANGODB_ROOT_USERNAME=myUserName

--- a/pyArango/tests/tests.py
+++ b/pyArango/tests/tests.py
@@ -1078,7 +1078,7 @@ class pyArangoTests(unittest.TestCase):
         # Create a mock AikidoSession class
         mock_aikido_session = MagicMock()
 
-        timeout = 30
+        timeout = 120
         connection = Connection(arangoURL='http://127.0.0.1:8529', username='root', password='root', timeout=timeout)
 
         # Call the reload method


### PR DESCRIPTION
This PR should give PyArango users a greater level or granularity for dictating the http header timeout. Most users should not need to use this, but it will be extremely useful to have so those than do.

The use case I found personally was in a multinode Kubernetes configuration in the event of node death the connection would hang indefinitely but using this simple http header in the AikidoSesson object I was able to avoid this and the connection would sever itself after the allocated timeout. 

I've included parameter in the standard Connection object so that users can access it easily without the need for excessive alternations to their code or the PyArango library.

Given that the likelihood of this connection issue is very minimal I think that a default timeout of 30 seconds should be fine and not affect any existing implementations. Furthermore if someone has already made monkey patch calls over the AikidoSesson object, they will still superceed any changes I have made here, rendering it safe for all users.

I have added a simple parameter test to ensure that the timeout value is propagated correctly through the code into the AikidoSesson itself.