### PR TITLE
Add support for client-side certificates

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+2.0.3
+=====
+* Added support for authentication via client-side certificates
+
 2.0.2
 =====
 * Fixed contains functions


### PR DESCRIPTION
This PR adds support for passing in the `cert` parameter to the session object (through the `AikidoSession` class).

I hope adding a new headline (with a new version number) to `CHANGELOG.rst` was the right move here. LMK if I should do this differently.

Limitations:

* I don't have time right how to understand `grequests` well enough to add this feature there as well. But I think throwing an exception in that case is better than not having client-side certificate support at all).
* I've reviewed the `tests` directory but don't really know where I would add a test for a feature like this. Would it be ok to merge this even though the `CONTRIBUTING.md` states that
> If you add a new feature please provide a test for it. Otherwise your pull request might be rejected.