### PR TITLE
added default setting on field access

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,9 @@
+2.1.1
+=====
+* Added missing fields value settings on getitem
+
+=====
+
 2.1.0
 =====
 * Added getitem for documents at the database level

--- a/pyArango/document.py
+++ b/pyArango/document.py
@@ -151,11 +151,15 @@ class DocumentStore(object):
         if self.collection._validation['allow_foreign_fields'] or self.collection.hasField(field):
             return self.store.get(field)
 
+        if not field in self.validators:
+            raise SchemaViolation(self.collection.__class__, field)
+
         try:
             return self.store[field]
         except KeyError:
-            raise SchemaViolation(self.collection.__class__, field)
-
+            self.store[field] = self.validators[field].default
+        return self.store[field]
+       
     def __setitem__(self, field, value):
         """Set an element in the store"""
         if self.mustValidate and (not self.collection._validation['allow_foreign_fields']) and (field not in self.validators) and (field not in self.collection.arangoPrivates):

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open(path.join(here, 'DESCRIPTION.rst'), encoding='utf-8') as f:
 setup(
     name='pyArango',
 
-    version='2.1.0',
+    version='2.1.1',
 
     description='An easy to use python driver for ArangoDB with built-in validation',
     long_description=long_description,


### PR DESCRIPTION
When a document field is accessed if it is missing from the schema the default value is automatically set. 
Handles the edege case where a field might be deleted from the database