### PR TITLE
Fix/string validator py3

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,9 @@
+2.1.2
+=====
+* Bugfix: ``NameError: unicode`` in ``String`` validator (``pyArango.validation``) for seamless Python 2 and Python 3 support
+
+=====
+
 2.1.1
 =====
 * Added missing fields value settings on getitem

--- a/pyArango/tests/validators_tests.py
+++ b/pyArango/tests/validators_tests.py
@@ -31,5 +31,34 @@ class ValidatorTests(unittest.TestCase):
         self.assertRaises(ValidationError, v.validate, '1')
         self.assertRaises(ValidationError, v.validate, '123456')
 
+    def test_string(self):
+        v = String()
+        good = [
+            "Hello World",
+            u"sadasda",   # unicode literal under Py2, str under Py3
+            ""
+        ]
+        for val in good:
+            self.assertTrue(v.validate(val), msg="Expected to accept {!r}".format(val))
+        bad = [
+            123,
+            None,
+            True,
+            False,
+            12.34,
+            [1, 2, 3],
+            {1: 'a', 2: 'b'},
+            b"Hello World",
+            bytearray(b"Hello World")
+        ]
+        for val in bad:
+            self.assertRaises(ValidationError, v.validate, val)
+        for val in (123, b"foo\nbar"):
+            with self.assertRaises(ValidationError) as cm:
+                v.validate(val)
+            err = str(cm.exception)
+            self.assertIn(repr(val), err)
+            self.assertIn("is not a valid string", err)
+
 if __name__ == "__main__":
     unittest.main()

--- a/pyArango/validation.py
+++ b/pyArango/validation.py
@@ -1,46 +1,56 @@
 from .theExceptions import ValidationError
 
+
 class Validator(object):
     """All validators must inherit from this class"""
     def __init__(self, *args, **kwrags):
         pass
 
     def validate(self, value):
-        """The only function that a validator must implement. Must return True if erevything went well or a ValidationError otherwise"""
-        raise NotImplemented("Should be implemented in child")
+        """The only function that a validator must implement.
+        Must return True if eveything
+        went well or a ValidationError otherwise
+        """
+        raise NotImplementedError("Should be implemented in child")
 
     def __str__(self):
-        """This function should be redifined in child to give a quick overview of the validator"""
+        """This function should be redifined in child
+        to give a quick overview of the validator"""
         return self.__class__.__name__
 
+
 class NotNull(Validator):
-    """Checks that the Field has a non null value. False is not considered a Null Value"""
+    """Checks that the Field has a non null value.
+    False is not considered a Null Value"""
     def __init__(self, reject_zero=False, reject_empty_string=True):
         self.reject_zero = reject_zero
         self.reject_empty_string = reject_empty_string
 
     def validate(self, value):
-        if value is None or ( (value == 0 and type(value) != bool ) and self.reject_zero) or (value == "" and self.reject_empty_string):
+        if value is None or ((value == 0 and type(value) is not bool) and self.reject_zero) or (value == "" and self.reject_empty_string):
             raise ValidationError("Field can't have a null value, got: '%s'" % value)
         return True
+
 
 class Email(Validator):
     """Checks if the field contains an emailaddress"""
     def validate(self, value):
         import re
-        pat = '^[A-z0-9._-]+@[A-z0-9.-]+\.[A-z]{2,4}$'
+        pat = r'^[A-z0-9._-]+@[A-z0-9.-]+\.[A-z]{2,4}$'
         if re.match(pat, value) is None:
             raise ValidationError("The email address: %s is invalid" % value)
         return True
+
 
 class Numeric(Validator):
     """checks if the value is numerical"""
     def validate(self, value):
         try:
             float(value)
-        except:
+        except (ValueError, TypeError):
             raise ValidationError("%s is not valid numerical value" % value)
         return True
+
 
 class Int(Validator):
     """The value must be an integer"""
@@ -49,6 +59,7 @@ class Int(Validator):
             raise ValidationError("%s is not a valid integer" % value)
         return True
 
+
 class Bool(Validator):
     """The value must be a boolean"""
     def validate(self, value):
@@ -56,22 +67,32 @@ class Bool(Validator):
             raise ValidationError("%s is not a valid boolean" % value)
         return True
 
+
+# Py2 has both str and unicode; Py3 only has str.
+try:
+    string_types = (str, unicode)
+except NameError:
+    string_types = (str,)
+
+
 class String(Validator):
     """The value must be a string or unicode"""
     def validate(self, value):
-        if not isinstance(value, str) and not isinstance(value, unicode):
-            raise ValidationError("%s is not a valid string" % value)
+        if not isinstance(value, string_types):
+            raise ValidationError("{!r} is not a valid string".format(value))
         return True
+
 
 class Enumeration(Validator):
     """The value must be in the allowed ones"""
     def __init__(self, allowed):
         self.allowed = set(allowed)
-  
+
     def validate(self, value):
         if value not in self.allowed:
             raise ValidationError("%s is not among the allowed values %s" % (value, self.allowed))
         return True
+
 
 class Range(Validator):
     """The value must une [lower, upper] range"""
@@ -82,7 +103,7 @@ class Range(Validator):
     def validate(self, value):
         if value < self.lower or value > self.upper:
             raise ValidationError("%s is not in [%s, %s]" % (value, self.lower, self.upper))
-    
+
     def __str__(self):
         return "%s[%s, %s]" % (self.__class__.__name__, self.minLen, self.maxLen)
 
@@ -95,13 +116,13 @@ class Length(Validator):
 
     def validate(self, value):
         try:
-            length = len(value)
-        except:
+            len(value)
+        except TypeError:
             raise ValidationError("Field '%s' of type '%s' has no length" % (value, type(value)))
-            
+
         if self.minLen <= len(value) and len(value) <= self.maxLen:
             return True
         raise ValidationError("Field must have a length in ['%s';'%s'] got: '%s'" % (self.minLen, self.maxLen, len(value)))
-    
+
     def __str__(self):
         return "%s[%s, %s]" % (self.__class__.__name__, self.minLen, self.maxLen)


### PR DESCRIPTION
# Fix Python 2/3 Validator Compatibility

- Add `string_types` shim (`(str, unicode)` on Py2, `(str,)` on Py3) to fix `NameError: unicode`  
- Use `repr(value)` in `ValidationError` for clear, quoted error messages.
- Change `type(value) != bool` to `type(value) is not bool` for proper identity checks.
- Replace bare `except:` with `except (ValueError, TypeError):` to avoid hiding unexpected errors.